### PR TITLE
phase-0: 0a — printer env wiring

### DIFF
--- a/api/cmd/services/ichor/main.go
+++ b/api/cmd/services/ichor/main.go
@@ -169,6 +169,10 @@ func run(ctx context.Context, log *logger.Logger) error {
 			Host           string `conf:"default:http://host.docker.internal:11434"` // Ollama only
 			ThinkingEffort string `conf:"default:high"`                              // Ollama only
 		}
+		Printer struct {
+			IP   string `conf:"default:172.16.60.116,mask"`
+			Port string `conf:"default:9100"`
+		}
 		Resend struct {
 			APIKey string `conf:"mask"` // ICHOR_RESEND_APIKEY — mask prevents logging
 			From   string              // ICHOR_RESEND_FROM e.g. "Ichor ERP <noreply@yourco.com>"

--- a/api/cmd/services/ichor/main.go
+++ b/api/cmd/services/ichor/main.go
@@ -170,7 +170,7 @@ func run(ctx context.Context, log *logger.Logger) error {
 			ThinkingEffort string `conf:"default:high"`                              // Ollama only
 		}
 		Printer struct {
-			IP   string `conf:"default:172.16.60.116,mask"`
+			IP   string `conf:"default:172.16.60.116"`
 			Port string `conf:"default:9100"`
 		}
 		Resend struct {

--- a/zarf/k8s/base/ichor/base-ichor.yaml
+++ b/zarf/k8s/base/ichor/base-ichor.yaml
@@ -168,6 +168,11 @@ spec:
                   key: api_key
                   optional: true
 
+            - name: ICHOR_PRINTER_IP
+              value: "172.16.60.116"
+            - name: ICHOR_PRINTER_PORT
+              value: "9100"
+
             - name: KUBERNETES_NAMESPACE
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
## Summary
- Adds `Printer.IP` / `Printer.Port` config group (default `172.16.60.116:9100`)
- Wires `ICHOR_PRINTER_IP` / `ICHOR_PRINTER_PORT` env on the ichor deployment
- Unblocks the `labelapp` TCP write path in ticket 0b

## Phase 0 ticket
0a

## Linked
- Spec: `docs/superpowers/specs/2026-04-14-floor-physical-warehouse-testing-design.md` §3.1
- Plan: `docs/superpowers/plans/floor-physical-warehouse-testing/phase-0-foundation.md`
- NOTES §8.4: physical reachability smoke test already verified (Mac + KIND-pod both green)

## Dependencies
Independent — PRs 1, 2, 6 can land in any order.

## Test plan
- [x] `nc` smoke from Mac: `nc -z -v -w 5 172.16.60.116 9100` → open
- [x] `nc` smoke from pod: `kubectl exec ... nc -z ...` → open
- [x] Local `go build ./...` + `go test ./...` green
- [ ] CI green after push
- [ ] After merge: `make dev-update-apply` and confirm `kubectl exec deploy/ichor -- sh -c 'echo $ICHOR_PRINTER_IP:$ICHOR_PRINTER_PORT'` prints `172.16.60.116:9100`

## Review tier
**Light** — config-only change, ~10 lines plus a follow-up 1-line fix (removing `,mask` from IP; not a secret, matches DB.Host/Auth.Host convention in this file).