### PR TITLE
phase-0: 0b — label subsystem backend

### DIFF
--- a/api/cmd/services/ichor/build/all/all.go
+++ b/api/cmd/services/ichor/build/all/all.go
@@ -16,6 +16,7 @@ import (
 	"github.com/timmaaaz/ichor/api/domain/http/assets/tagapi"
 	"github.com/timmaaaz/ichor/api/domain/http/assets/userassetapi"
 	"github.com/timmaaaz/ichor/api/domain/http/assets/validassetapi"
+	"github.com/timmaaaz/ichor/api/domain/http/labels/labelapi"
 	"github.com/timmaaaz/ichor/api/domain/http/config/formapi"
 	"github.com/timmaaaz/ichor/api/domain/http/config/formfieldapi"
 	"github.com/timmaaaz/ichor/api/domain/http/config/configschemaapi"
@@ -114,6 +115,7 @@ import (
 	"github.com/timmaaaz/ichor/app/domain/assets/tagapp"
 	"github.com/timmaaaz/ichor/app/domain/assets/userassetapp"
 	"github.com/timmaaaz/ichor/app/domain/assets/validassetapp"
+	"github.com/timmaaaz/ichor/app/domain/labels/labelapp"
 	"github.com/timmaaaz/ichor/app/domain/config/formapp"
 	"github.com/timmaaaz/ichor/app/domain/config/formfieldapp"
 	"github.com/timmaaaz/ichor/app/domain/config/pageactionapp"
@@ -172,6 +174,9 @@ import (
 	"github.com/timmaaaz/ichor/business/domain/assets/approvalstatusbus/stores/approvalstatusdb"
 	"github.com/timmaaaz/ichor/business/domain/assets/assetbus"
 	"github.com/timmaaaz/ichor/business/domain/assets/assetbus/stores/assetdb"
+	"github.com/timmaaaz/ichor/business/domain/labels/labelbus"
+	"github.com/timmaaaz/ichor/business/domain/labels/labelbus/stores/labeldb"
+	"github.com/timmaaaz/ichor/business/domain/labels/labelbus/tcpprint"
 	"github.com/timmaaaz/ichor/business/domain/assets/validassetbus"
 	validassetdb "github.com/timmaaaz/ichor/business/domain/assets/validassetbus/stores/assetdb"
 	"github.com/timmaaaz/ichor/business/domain/config/formbus"
@@ -815,6 +820,19 @@ func (a add) Add(app *web.App, cfg mux.Config) {
 		AuthClient:     cfg.AuthClient,
 		Log:            cfg.Log,
 		PermissionsBus: permissionsBus,
+	})
+
+	// Label subsystem (Phase 0b) — catalog + transaction-label printing
+	// via ZPL over TCP to a Zebra-compatible printer. PrinterIP/Port come
+	// from ICHOR_PRINTER_* via mux.Config (Phase 0a).
+	labelStorer := labeldb.NewStore(cfg.Log, cfg.DB)
+	labelPrinter := tcpprint.New(cfg.PrinterIP, cfg.PrinterPort, 5*time.Second)
+	labelBus := labelbus.NewBusiness(cfg.Log, delegate, labelStorer, labelPrinter)
+	labelAppInst := labelapp.NewApp(labelBus)
+	labelapi.Routes(app, labelapi.Config{
+		Log:        cfg.Log,
+		LabelApp:   labelAppInst,
+		AuthClient: cfg.AuthClient,
 	})
 
 	approvalapi.Routes(app, approvalapi.Config{

--- a/api/cmd/services/ichor/build/all/all.go
+++ b/api/cmd/services/ichor/build/all/all.go
@@ -653,6 +653,9 @@ func (a add) Add(app *web.App, cfg mux.Config) {
 			delegateHandler.RegisterDomain(delegate, pagecontentbus.DomainName, pagecontentbus.EntityName)
 			delegateHandler.RegisterDomain(delegate, pageactionbus.DomainName, pageactionbus.EntityName)
 
+			// Labels domain
+			delegateHandler.RegisterDomain(delegate, labelbus.DomainName, labelbus.EntityName)
+
 			cfg.Log.Info(context.Background(), "temporal workflow infrastructure initialized")
 		}
 	} else {

--- a/api/cmd/services/ichor/build/all/all.go
+++ b/api/cmd/services/ichor/build/all/all.go
@@ -115,7 +115,6 @@ import (
 	"github.com/timmaaaz/ichor/app/domain/assets/tagapp"
 	"github.com/timmaaaz/ichor/app/domain/assets/userassetapp"
 	"github.com/timmaaaz/ichor/app/domain/assets/validassetapp"
-	"github.com/timmaaaz/ichor/app/domain/labels/labelapp"
 	"github.com/timmaaaz/ichor/app/domain/config/formapp"
 	"github.com/timmaaaz/ichor/app/domain/config/formfieldapp"
 	"github.com/timmaaaz/ichor/app/domain/config/pageactionapp"
@@ -827,15 +826,21 @@ func (a add) Add(app *web.App, cfg mux.Config) {
 
 	// Label subsystem (Phase 0b) — catalog + transaction-label printing
 	// via ZPL over TCP to a Zebra-compatible printer. PrinterIP/Port come
-	// from ICHOR_PRINTER_* via mux.Config (Phase 0a).
+	// from ICHOR_PRINTER_* via mux.Config (Phase 0a). Tests substitute a
+	// recording printer through cfg.LabelPrinter to assert ZPL dispatch.
 	labelStorer := labeldb.NewStore(cfg.Log, cfg.DB)
-	labelPrinter := tcpprint.New(cfg.PrinterIP, cfg.PrinterPort, 5*time.Second)
+	var labelPrinter labelbus.Printer
+	if cfg.LabelPrinter != nil {
+		labelPrinter = cfg.LabelPrinter
+	} else {
+		labelPrinter = tcpprint.New(cfg.PrinterIP, cfg.PrinterPort, 5*time.Second)
+	}
 	labelBus := labelbus.NewBusiness(cfg.Log, delegate, labelStorer, labelPrinter)
-	labelAppInst := labelapp.NewApp(labelBus)
 	labelapi.Routes(app, labelapi.Config{
-		Log:        cfg.Log,
-		LabelApp:   labelAppInst,
-		AuthClient: cfg.AuthClient,
+		Log:            cfg.Log,
+		LabelBus:       labelBus,
+		AuthClient:     cfg.AuthClient,
+		PermissionsBus: permissionsBus,
 	})
 
 	approvalapi.Routes(app, approvalapi.Config{

--- a/api/cmd/services/ichor/main.go
+++ b/api/cmd/services/ichor/main.go
@@ -371,6 +371,8 @@ func run(ctx context.Context, log *logger.Logger) error {
 		LLMThinkingEffort: cfg.LLM.ThinkingEffort,
 		ResendAPIKey:       cfg.Resend.APIKey,
 		ResendFrom:         cfg.Resend.From,
+		PrinterIP:          cfg.Printer.IP,
+		PrinterPort:        cfg.Printer.Port,
 		CORSAllowedOrigins: cfg.Web.CORSAllowedOrigins,
 	}
 

--- a/api/cmd/services/ichor/tests/labels/labelapi/create_test.go
+++ b/api/cmd/services/ichor/tests/labels/labelapi/create_test.go
@@ -1,0 +1,186 @@
+package labelapi_test
+
+import (
+	"net/http"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/timmaaaz/ichor/api/sdk/http/apitest"
+	"github.com/timmaaaz/ichor/app/domain/labels/labelapp"
+	"github.com/timmaaaz/ichor/app/sdk/errs"
+)
+
+func create200(sd apitest.SeedData) []apitest.Table {
+	return []apitest.Table{
+		{
+			Name:       "basic",
+			URL:        "/v1/labels",
+			Token:      sd.Admins[0].Token,
+			Method:     http.MethodPost,
+			StatusCode: http.StatusOK,
+			Input: &labelapp.NewLabel{
+				Code: "NEW-CREATE-001",
+				Type: "location",
+			},
+			GotResp: &labelapp.Label{},
+			ExpResp: &labelapp.Label{
+				Code: "NEW-CREATE-001",
+				Type: "location",
+			},
+			CmpFunc: func(got, exp any) string {
+				gotResp := got.(*labelapp.Label)
+				expResp := exp.(*labelapp.Label)
+
+				expResp.ID = gotResp.ID
+				expResp.CreatedDate = gotResp.CreatedDate
+
+				return cmp.Diff(gotResp, expResp)
+			},
+		},
+		{
+			Name:       "with-entity-ref-and-payload",
+			URL:        "/v1/labels",
+			Token:      sd.Admins[0].Token,
+			Method:     http.MethodPost,
+			StatusCode: http.StatusOK,
+			Input: &labelapp.NewLabel{
+				Code:        "NEW-CREATE-002",
+				Type:        "tote",
+				EntityRef:   "TOTE-A1",
+				PayloadJSON: `{"capacity":50}`,
+			},
+			GotResp: &labelapp.Label{},
+			ExpResp: &labelapp.Label{
+				Code:        "NEW-CREATE-002",
+				Type:        "tote",
+				EntityRef:   "TOTE-A1",
+				PayloadJSON: `{"capacity":50}`,
+			},
+			CmpFunc: func(got, exp any) string {
+				gotResp := got.(*labelapp.Label)
+				expResp := exp.(*labelapp.Label)
+
+				expResp.ID = gotResp.ID
+				expResp.CreatedDate = gotResp.CreatedDate
+
+				return cmp.Diff(gotResp, expResp)
+			},
+		},
+	}
+}
+
+func create400(sd apitest.SeedData) []apitest.Table {
+	return []apitest.Table{
+		{
+			Name:       "missing-code",
+			URL:        "/v1/labels",
+			Token:      sd.Admins[0].Token,
+			Method:     http.MethodPost,
+			StatusCode: http.StatusBadRequest,
+			Input: &labelapp.NewLabel{
+				Type: "location",
+			},
+			GotResp: &errs.Error{},
+			ExpResp: errs.Newf(errs.InvalidArgument, `validate: [{"field":"code","error":"code is a required field"}]`),
+			CmpFunc: func(got, exp any) string {
+				return cmp.Diff(got, exp)
+			},
+		},
+		{
+			Name:       "missing-type",
+			URL:        "/v1/labels",
+			Token:      sd.Admins[0].Token,
+			Method:     http.MethodPost,
+			StatusCode: http.StatusBadRequest,
+			Input: &labelapp.NewLabel{
+				Code: "NEW-BAD-001",
+			},
+			GotResp: &errs.Error{},
+			ExpResp: errs.Newf(errs.InvalidArgument, `validate: [{"field":"type","error":"type is a required field"}]`),
+			CmpFunc: func(got, exp any) string {
+				return cmp.Diff(got, exp)
+			},
+		},
+		{
+			Name:       "invalid-type",
+			URL:        "/v1/labels",
+			Token:      sd.Admins[0].Token,
+			Method:     http.MethodPost,
+			StatusCode: http.StatusBadRequest,
+			Input: &labelapp.NewLabel{
+				Code: "NEW-BAD-002",
+				Type: "not_a_valid_type",
+			},
+			GotResp: &errs.Error{},
+			ExpResp: errs.Newf(errs.InvalidArgument, `validate: [{"field":"type","error":"type must be one of [location tote lot serial product receiving pick]"}]`),
+			CmpFunc: func(got, exp any) string {
+				return cmp.Diff(got, exp)
+			},
+		},
+	}
+}
+
+func create401(sd apitest.SeedData) []apitest.Table {
+	return []apitest.Table{
+		{
+			Name:       "empty-token",
+			URL:        "/v1/labels",
+			Token:      "&nbsp;",
+			Method:     http.MethodPost,
+			StatusCode: http.StatusUnauthorized,
+			GotResp:    &errs.Error{},
+			ExpResp:    errs.Newf(errs.Unauthenticated, "error parsing token: token contains an invalid number of segments"),
+			CmpFunc: func(got, exp any) string {
+				return cmp.Diff(got, exp)
+			},
+		},
+		{
+			Name:       "bad-sig",
+			URL:        "/v1/labels",
+			Token:      sd.Admins[0].Token + "A",
+			Method:     http.MethodPost,
+			StatusCode: http.StatusUnauthorized,
+			GotResp:    &errs.Error{},
+			ExpResp:    errs.Newf(errs.Unauthenticated, "authentication failed : bindings results[[{[true] map[x:false]}]] ok[true]"),
+			CmpFunc: func(got, exp any) string {
+				return cmp.Diff(got, exp)
+			},
+		},
+		{
+			Name:       "no-create-permission",
+			URL:        "/v1/labels",
+			Token:      sd.Users[0].Token,
+			Method:     http.MethodPost,
+			StatusCode: http.StatusForbidden,
+			Input: &labelapp.NewLabel{
+				Code: "FORBIDDEN-001",
+				Type: "location",
+			},
+			GotResp: &errs.Error{},
+			ExpResp: errs.Newf(errs.PermissionDenied, "user does not have permission CREATE for table: inventory.label_catalog"),
+			CmpFunc: func(got, exp any) string {
+				return cmp.Diff(got, exp)
+			},
+		},
+	}
+}
+
+func create409(sd apitest.SeedData) []apitest.Table {
+	return []apitest.Table{
+		{
+			Name:       "duplicate-code",
+			URL:        "/v1/labels",
+			Token:      sd.Admins[0].Token,
+			Method:     http.MethodPost,
+			StatusCode: http.StatusConflict,
+			Input: &labelapp.NewLabel{
+				Code: sd.Labels[0].Code,
+				Type: "location",
+			},
+			GotResp: &errs.Error{},
+			ExpResp: errs.Newf(errs.Aborted, "label code already exists"),
+			CmpFunc: func(got, exp any) string {
+				return cmp.Diff(got, exp)
+			},
+		},
+	}
+}

--- a/api/cmd/services/ichor/tests/labels/labelapi/delete_test.go
+++ b/api/cmd/services/ichor/tests/labels/labelapi/delete_test.go
@@ -1,0 +1,81 @@
+package labelapi_test
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
+	"github.com/timmaaaz/ichor/api/sdk/http/apitest"
+	"github.com/timmaaaz/ichor/app/sdk/errs"
+)
+
+func delete200(sd apitest.SeedData) []apitest.Table {
+	return []apitest.Table{
+		{
+			Name:       "basic",
+			URL:        fmt.Sprintf("/v1/labels/%s", sd.Labels[3].ID),
+			Token:      sd.Admins[0].Token,
+			Method:     http.MethodDelete,
+			StatusCode: http.StatusNoContent,
+		},
+	}
+}
+
+func delete401(sd apitest.SeedData) []apitest.Table {
+	return []apitest.Table{
+		{
+			Name:       "empty-token",
+			URL:        fmt.Sprintf("/v1/labels/%s", sd.Labels[0].ID),
+			Token:      "&nbsp;",
+			Method:     http.MethodDelete,
+			StatusCode: http.StatusUnauthorized,
+			GotResp:    &errs.Error{},
+			ExpResp:    errs.Newf(errs.Unauthenticated, "error parsing token: token contains an invalid number of segments"),
+			CmpFunc: func(got, exp any) string {
+				return cmp.Diff(got, exp)
+			},
+		},
+		{
+			Name:       "bad-sig",
+			URL:        fmt.Sprintf("/v1/labels/%s", sd.Labels[0].ID),
+			Token:      sd.Admins[0].Token + "A",
+			Method:     http.MethodDelete,
+			StatusCode: http.StatusUnauthorized,
+			GotResp:    &errs.Error{},
+			ExpResp:    errs.Newf(errs.Unauthenticated, "authentication failed : bindings results[[{[true] map[x:false]}]] ok[true]"),
+			CmpFunc: func(got, exp any) string {
+				return cmp.Diff(got, exp)
+			},
+		},
+		{
+			Name:       "no-delete-permission",
+			URL:        fmt.Sprintf("/v1/labels/%s", sd.Labels[0].ID),
+			Token:      sd.Users[0].Token,
+			Method:     http.MethodDelete,
+			StatusCode: http.StatusForbidden,
+			GotResp:    &errs.Error{},
+			ExpResp:    errs.Newf(errs.PermissionDenied, "user does not have permission DELETE for table: inventory.label_catalog"),
+			CmpFunc: func(got, exp any) string {
+				return cmp.Diff(got, exp)
+			},
+		},
+	}
+}
+
+func delete404(sd apitest.SeedData) []apitest.Table {
+	return []apitest.Table{
+		{
+			Name:       "not-found",
+			URL:        fmt.Sprintf("/v1/labels/%s", uuid.NewString()),
+			Token:      sd.Admins[0].Token,
+			Method:     http.MethodDelete,
+			StatusCode: http.StatusNotFound,
+			GotResp:    &errs.Error{},
+			ExpResp:    errs.Newf(errs.NotFound, "label not found"),
+			CmpFunc: func(got, exp any) string {
+				return cmp.Diff(got, exp)
+			},
+		},
+	}
+}

--- a/api/cmd/services/ichor/tests/labels/labelapi/labels_test.go
+++ b/api/cmd/services/ichor/tests/labels/labelapi/labels_test.go
@@ -1,0 +1,52 @@
+package labelapi_test
+
+import (
+	"testing"
+
+	"github.com/timmaaaz/ichor/api/sdk/http/apitest"
+)
+
+func Test_Labels(t *testing.T) {
+	t.Parallel()
+
+	test, printer := apitest.StartLabelTest(t, "Test_Labels")
+
+	sd, err := insertSeedData(test.DB, test.Auth)
+	if err != nil {
+		t.Fatalf("Seeding error: %s", err)
+	}
+
+	// Query
+	test.Run(t, query200(sd), "query-200")
+	test.Run(t, query401(sd), "query-401")
+	test.Run(t, queryByID200(sd), "query-by-id-200")
+	test.Run(t, queryByID401(sd), "query-by-id-401")
+	test.Run(t, queryByID404(sd), "query-by-id-404")
+
+	// Create
+	test.Run(t, create200(sd), "create-200")
+	test.Run(t, create400(sd), "create-400")
+	test.Run(t, create401(sd), "create-401")
+	test.Run(t, create409(sd), "create-409")
+
+	// Update
+	test.Run(t, update200(sd), "update-200")
+	test.Run(t, update400(sd), "update-400")
+	test.Run(t, update401(sd), "update-401")
+	test.Run(t, update404(sd), "update-404")
+
+	// Delete
+	// Delete runs after Print/RenderPrint so the print tests can use sd.Labels[3]
+	// without a not-found race. Reordered below.
+
+	// Print (catalog)
+	runPrintTests(t, test, printer, sd)
+
+	// Render-print (transaction)
+	runRenderPrintTests(t, test, printer, sd)
+
+	test.Run(t, delete200(sd), "delete-200")
+	test.Run(t, delete401(sd), "delete-401")
+	test.Run(t, delete404(sd), "delete-404")
+
+}

--- a/api/cmd/services/ichor/tests/labels/labelapi/print_test.go
+++ b/api/cmd/services/ichor/tests/labels/labelapi/print_test.go
@@ -1,0 +1,144 @@
+package labelapi_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/timmaaaz/ichor/api/sdk/http/apitest"
+	"github.com/timmaaaz/ichor/app/domain/labels/labelapp"
+)
+
+// runPrintTests covers POST /v1/labels/print. Unlike the table-driven Run()
+// helper, these tests need to inspect the RecPrinter between calls, so they
+// drive the mux directly via httptest.
+func runPrintTests(t *testing.T, test *apitest.Test, printer *apitest.RecPrinter, sd apitest.SeedData) {
+	t.Run("print-200-single-copy", func(t *testing.T) {
+		printer.Reset()
+
+		// sd.Labels[2] is untouched by the upstream update/delete cases;
+		// using sd.Labels[0] here would assert on a captured-at-seed-time
+		// Code value that the update-200 test has since patched.
+		body := mustJSON(t, labelapp.PrintRequest{
+			LabelID: sd.Labels[2].ID,
+		})
+		req := httptest.NewRequest(http.MethodPost, "/v1/labels/print", bytes.NewReader(body))
+		req.Header.Set("Authorization", "Bearer "+sd.Admins[0].Token)
+		w := httptest.NewRecorder()
+		test.ServeHTTP(w, req)
+
+		if w.Code != http.StatusNoContent {
+			t.Fatalf("status: got %d want %d body=%s", w.Code, http.StatusNoContent, w.Body.String())
+		}
+		calls := printer.Calls()
+		if len(calls) != 1 {
+			t.Fatalf("printer calls: got %d want 1", len(calls))
+		}
+		if !bytes.Contains(calls[0], []byte(sd.Labels[2].Code)) {
+			t.Fatalf("ZPL did not contain label code %q; got %s", sd.Labels[2].Code, calls[0])
+		}
+	})
+
+	t.Run("print-200-three-copies", func(t *testing.T) {
+		printer.Reset()
+
+		body := mustJSON(t, labelapp.PrintRequest{
+			LabelID: sd.Labels[1].ID,
+			Copies:  3,
+		})
+		req := httptest.NewRequest(http.MethodPost, "/v1/labels/print", bytes.NewReader(body))
+		req.Header.Set("Authorization", "Bearer "+sd.Admins[0].Token)
+		w := httptest.NewRecorder()
+		test.ServeHTTP(w, req)
+
+		if w.Code != http.StatusNoContent {
+			t.Fatalf("status: got %d body=%s", w.Code, w.Body.String())
+		}
+		if got := len(printer.Calls()); got != 3 {
+			t.Fatalf("printer calls: got %d want 3", got)
+		}
+	})
+
+	t.Run("print-400-bad-uuid", func(t *testing.T) {
+		printer.Reset()
+
+		body := mustJSON(t, labelapp.PrintRequest{LabelID: "not-a-uuid"})
+		req := httptest.NewRequest(http.MethodPost, "/v1/labels/print", bytes.NewReader(body))
+		req.Header.Set("Authorization", "Bearer "+sd.Admins[0].Token)
+		w := httptest.NewRecorder()
+		test.ServeHTTP(w, req)
+
+		// validate:"required,min=36,max=36" rejects strings that aren't 36 chars.
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status: got %d want %d body=%s", w.Code, http.StatusBadRequest, w.Body.String())
+		}
+		if got := len(printer.Calls()); got != 0 {
+			t.Fatalf("printer should not be called on validation failure; got %d calls", got)
+		}
+	})
+
+	t.Run("print-401-empty-token", func(t *testing.T) {
+		printer.Reset()
+
+		body := mustJSON(t, labelapp.PrintRequest{LabelID: sd.Labels[0].ID})
+		req := httptest.NewRequest(http.MethodPost, "/v1/labels/print", bytes.NewReader(body))
+		req.Header.Set("Authorization", "Bearer &nbsp;")
+		w := httptest.NewRecorder()
+		test.ServeHTTP(w, req)
+
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("status: got %d want %d body=%s", w.Code, http.StatusUnauthorized, w.Body.String())
+		}
+		if got := len(printer.Calls()); got != 0 {
+			t.Fatalf("printer should not be called on auth failure; got %d calls", got)
+		}
+	})
+
+	t.Run("print-403-no-read-permission", func(t *testing.T) {
+		printer.Reset()
+
+		body := mustJSON(t, labelapp.PrintRequest{LabelID: sd.Labels[0].ID})
+		req := httptest.NewRequest(http.MethodPost, "/v1/labels/print", bytes.NewReader(body))
+		req.Header.Set("Authorization", "Bearer "+sd.Users[0].Token)
+		w := httptest.NewRecorder()
+		test.ServeHTTP(w, req)
+
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("status: got %d want %d body=%s", w.Code, http.StatusForbidden, w.Body.String())
+		}
+		if got := len(printer.Calls()); got != 0 {
+			t.Fatalf("printer should not be called on permission failure; got %d calls", got)
+		}
+	})
+
+	t.Run("print-404-missing-label", func(t *testing.T) {
+		printer.Reset()
+
+		body := mustJSON(t, labelapp.PrintRequest{LabelID: uuid.NewString()})
+		req := httptest.NewRequest(http.MethodPost, "/v1/labels/print", bytes.NewReader(body))
+		req.Header.Set("Authorization", "Bearer "+sd.Admins[0].Token)
+		w := httptest.NewRecorder()
+		test.ServeHTTP(w, req)
+
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("status: got %d want %d body=%s", w.Code, http.StatusNotFound, w.Body.String())
+		}
+		if got := len(printer.Calls()); got != 0 {
+			t.Fatalf("printer should not be called when label is missing; got %d calls", got)
+		}
+	})
+}
+
+// mustJSON is a tiny helper so each subtest reads as a single statement.
+func mustJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %s", err)
+	}
+	return b
+}
+

--- a/api/cmd/services/ichor/tests/labels/labelapi/query_test.go
+++ b/api/cmd/services/ichor/tests/labels/labelapi/query_test.go
@@ -1,0 +1,148 @@
+package labelapi_test
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
+	"github.com/timmaaaz/ichor/api/sdk/http/apitest"
+	"github.com/timmaaaz/ichor/app/domain/labels/labelapp"
+	"github.com/timmaaaz/ichor/app/sdk/errs"
+)
+
+func query200(sd apitest.SeedData) []apitest.Table {
+	return []apitest.Table{
+		{
+			Name:       "all-labels",
+			URL:        "/v1/labels?rows=100&page=1",
+			Token:      sd.Admins[0].Token,
+			Method:     http.MethodGet,
+			StatusCode: http.StatusOK,
+			GotResp:    &labelapp.Labels{},
+			ExpResp:    nil,
+			// We can't easily diff against a fixed slice — the seedFrontend
+			// chain inserts ~39 catalog labels in addition to the four this
+			// test seeds, and InsertSeedData is not invoked by NewDatabase.
+			// What we *can* assert: every test-seeded label appears in the
+			// response, in order.
+			CmpFunc: func(got, _ any) string {
+				gotResp := got.(*labelapp.Labels)
+				seen := make(map[string]bool, len(*gotResp))
+				for _, lc := range *gotResp {
+					seen[lc.ID] = true
+				}
+				for _, expected := range sd.Labels {
+					if !seen[expected.ID] {
+						return fmt.Sprintf("seeded label %s missing from query response", expected.ID)
+					}
+				}
+				return ""
+			},
+		},
+	}
+}
+
+func queryByID200(sd apitest.SeedData) []apitest.Table {
+	return []apitest.Table{
+		{
+			Name:       "basic",
+			URL:        fmt.Sprintf("/v1/labels/%s", sd.Labels[0].ID),
+			Token:      sd.Admins[0].Token,
+			Method:     http.MethodGet,
+			StatusCode: http.StatusOK,
+			GotResp:    &labelapp.Label{},
+			ExpResp:    &sd.Labels[0],
+			CmpFunc: func(got, exp any) string {
+				return cmp.Diff(got, exp)
+			},
+		},
+	}
+}
+
+func queryByID404(sd apitest.SeedData) []apitest.Table {
+	return []apitest.Table{
+		{
+			Name:       "not-found",
+			URL:        fmt.Sprintf("/v1/labels/%s", uuid.NewString()),
+			Token:      sd.Admins[0].Token,
+			Method:     http.MethodGet,
+			StatusCode: http.StatusNotFound,
+			GotResp:    &errs.Error{},
+			ExpResp:    errs.Newf(errs.NotFound, "label not found"),
+			CmpFunc: func(got, exp any) string {
+				return cmp.Diff(got, exp)
+			},
+		},
+	}
+}
+
+func query401(sd apitest.SeedData) []apitest.Table {
+	return []apitest.Table{
+		{
+			Name:       "empty-token",
+			URL:        "/v1/labels?rows=10&page=1",
+			Token:      "&nbsp;",
+			Method:     http.MethodGet,
+			StatusCode: http.StatusUnauthorized,
+			GotResp:    &errs.Error{},
+			ExpResp:    errs.Newf(errs.Unauthenticated, "error parsing token: token contains an invalid number of segments"),
+			CmpFunc: func(got, exp any) string {
+				return cmp.Diff(got, exp)
+			},
+		},
+		{
+			Name:       "bad-sig",
+			URL:        "/v1/labels?rows=10&page=1",
+			Token:      sd.Admins[0].Token + "A",
+			Method:     http.MethodGet,
+			StatusCode: http.StatusUnauthorized,
+			GotResp:    &errs.Error{},
+			ExpResp:    errs.Newf(errs.Unauthenticated, "authentication failed : bindings results[[{[true] map[x:false]}]] ok[true]"),
+			CmpFunc: func(got, exp any) string {
+				return cmp.Diff(got, exp)
+			},
+		},
+		{
+			Name:       "no-read-permission",
+			URL:        "/v1/labels?rows=10&page=1",
+			Token:      sd.Users[0].Token,
+			Method:     http.MethodGet,
+			StatusCode: http.StatusForbidden,
+			GotResp:    &errs.Error{},
+			ExpResp:    errs.Newf(errs.PermissionDenied, "user does not have permission READ for table: inventory.label_catalog"),
+			CmpFunc: func(got, exp any) string {
+				return cmp.Diff(got, exp)
+			},
+		},
+	}
+}
+
+func queryByID401(sd apitest.SeedData) []apitest.Table {
+	return []apitest.Table{
+		{
+			Name:       "empty-token",
+			URL:        fmt.Sprintf("/v1/labels/%s", sd.Labels[0].ID),
+			Token:      "&nbsp;",
+			Method:     http.MethodGet,
+			StatusCode: http.StatusUnauthorized,
+			GotResp:    &errs.Error{},
+			ExpResp:    errs.Newf(errs.Unauthenticated, "error parsing token: token contains an invalid number of segments"),
+			CmpFunc: func(got, exp any) string {
+				return cmp.Diff(got, exp)
+			},
+		},
+		{
+			Name:       "no-read-permission",
+			URL:        fmt.Sprintf("/v1/labels/%s", sd.Labels[0].ID),
+			Token:      sd.Users[0].Token,
+			Method:     http.MethodGet,
+			StatusCode: http.StatusForbidden,
+			GotResp:    &errs.Error{},
+			ExpResp:    errs.Newf(errs.PermissionDenied, "user does not have permission READ for table: inventory.label_catalog"),
+			CmpFunc: func(got, exp any) string {
+				return cmp.Diff(got, exp)
+			},
+		},
+	}
+}

--- a/api/cmd/services/ichor/tests/labels/labelapi/render_print_test.go
+++ b/api/cmd/services/ichor/tests/labels/labelapi/render_print_test.go
@@ -1,0 +1,129 @@
+package labelapi_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/timmaaaz/ichor/api/sdk/http/apitest"
+	"github.com/timmaaaz/ichor/app/domain/labels/labelapp"
+)
+
+// runRenderPrintTests covers POST /v1/labels/render-print. Like print_test,
+// these subtests inspect the recorded ZPL between calls so they bypass the
+// table-driven Run() helper and drive the mux directly.
+func runRenderPrintTests(t *testing.T, test *apitest.Test, printer *apitest.RecPrinter, sd apitest.SeedData) {
+	t.Run("render-print-200-receiving", func(t *testing.T) {
+		printer.Reset()
+
+		payload := mustJSON(t, map[string]any{
+			"productName": "Widget",
+			"sku":         "SKU-RP-1",
+			"upc":         "012345678905",
+			"quantity":    10,
+			"poNumber":    "PO-99",
+		})
+
+		body := mustJSON(t, labelapp.RenderPrintRequest{
+			Type:    "receiving",
+			Payload: json.RawMessage(payload),
+			Copies:  2,
+		})
+		req := httptest.NewRequest(http.MethodPost, "/v1/labels/render-print", bytes.NewReader(body))
+		req.Header.Set("Authorization", "Bearer "+sd.Admins[0].Token)
+		w := httptest.NewRecorder()
+		test.ServeHTTP(w, req)
+
+		if w.Code != http.StatusNoContent {
+			t.Fatalf("status: got %d body=%s", w.Code, w.Body.String())
+		}
+		calls := printer.Calls()
+		if len(calls) != 2 {
+			t.Fatalf("printer calls: got %d want 2", len(calls))
+		}
+		if !bytes.Contains(calls[0], []byte("PO-99")) {
+			t.Fatalf("ZPL did not contain PO-99: %s", calls[0])
+		}
+	})
+
+	t.Run("render-print-400-bad-type", func(t *testing.T) {
+		printer.Reset()
+
+		body := mustJSON(t, labelapp.RenderPrintRequest{
+			Type:    "not_a_valid_type",
+			Payload: json.RawMessage(`{}`),
+		})
+		req := httptest.NewRequest(http.MethodPost, "/v1/labels/render-print", bytes.NewReader(body))
+		req.Header.Set("Authorization", "Bearer "+sd.Admins[0].Token)
+		w := httptest.NewRecorder()
+		test.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status: got %d want %d body=%s", w.Code, http.StatusBadRequest, w.Body.String())
+		}
+		if got := len(printer.Calls()); got != 0 {
+			t.Fatalf("printer should not be called on validation failure; got %d", got)
+		}
+	})
+
+	t.Run("render-print-400-missing-payload", func(t *testing.T) {
+		printer.Reset()
+
+		// Sending raw JSON without a "payload" key triggers the
+		// validate:"required" tag on RenderPrintRequest.Payload.
+		body := []byte(`{"type":"receiving"}`)
+		req := httptest.NewRequest(http.MethodPost, "/v1/labels/render-print", bytes.NewReader(body))
+		req.Header.Set("Authorization", "Bearer "+sd.Admins[0].Token)
+		w := httptest.NewRecorder()
+		test.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status: got %d want %d body=%s", w.Code, http.StatusBadRequest, w.Body.String())
+		}
+		if got := len(printer.Calls()); got != 0 {
+			t.Fatalf("printer should not be called on validation failure; got %d", got)
+		}
+	})
+
+	t.Run("render-print-401-empty-token", func(t *testing.T) {
+		printer.Reset()
+
+		body := mustJSON(t, labelapp.RenderPrintRequest{
+			Type:    "receiving",
+			Payload: json.RawMessage(`{"productName":"X"}`),
+		})
+		req := httptest.NewRequest(http.MethodPost, "/v1/labels/render-print", bytes.NewReader(body))
+		req.Header.Set("Authorization", "Bearer &nbsp;")
+		w := httptest.NewRecorder()
+		test.ServeHTTP(w, req)
+
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("status: got %d body=%s", w.Code, w.Body.String())
+		}
+		if got := len(printer.Calls()); got != 0 {
+			t.Fatalf("printer should not be called on auth failure; got %d", got)
+		}
+	})
+
+	t.Run("render-print-403-no-read-permission", func(t *testing.T) {
+		printer.Reset()
+
+		body := mustJSON(t, labelapp.RenderPrintRequest{
+			Type:    "receiving",
+			Payload: json.RawMessage(`{"productName":"X"}`),
+		})
+		req := httptest.NewRequest(http.MethodPost, "/v1/labels/render-print", bytes.NewReader(body))
+		req.Header.Set("Authorization", "Bearer "+sd.Users[0].Token)
+		w := httptest.NewRecorder()
+		test.ServeHTTP(w, req)
+
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("status: got %d body=%s", w.Code, w.Body.String())
+		}
+		if got := len(printer.Calls()); got != 0 {
+			t.Fatalf("printer should not be called on permission failure; got %d", got)
+		}
+	})
+}

--- a/api/cmd/services/ichor/tests/labels/labelapi/seed_test.go
+++ b/api/cmd/services/ichor/tests/labels/labelapi/seed_test.go
@@ -1,0 +1,121 @@
+package labelapi_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/timmaaaz/ichor/api/domain/http/labels/labelapi"
+	"github.com/timmaaaz/ichor/api/sdk/http/apitest"
+	"github.com/timmaaaz/ichor/app/domain/labels/labelapp"
+	"github.com/timmaaaz/ichor/app/sdk/auth"
+	"github.com/timmaaaz/ichor/business/domain/core/rolebus"
+	"github.com/timmaaaz/ichor/business/domain/core/tableaccessbus"
+	"github.com/timmaaaz/ichor/business/domain/core/userbus"
+	"github.com/timmaaaz/ichor/business/domain/core/userrolebus"
+	"github.com/timmaaaz/ichor/business/domain/labels/labelbus"
+	"github.com/timmaaaz/ichor/business/sdk/dbtest"
+)
+
+// insertSeedData stages everything the labels integration tests need:
+//   - one regular user (non-admin) whose label_catalog table_access is then
+//     downgraded to 0 perms so 403 PermissionDenied tests fire reliably
+//   - one admin user with full access (used for happy-path operations)
+//   - a fixed set of label catalog rows for query/update/delete cases
+//
+// Mirrors the cyclecountitemapi seed_test pattern verbatim — the role
+// downgrade loop is what makes 403 tests actually return 403.
+func insertSeedData(db *dbtest.Database, ath *auth.Auth) (apitest.SeedData, error) {
+	ctx := context.Background()
+	busDomain := db.BusDomain
+
+	// =========================================================================
+	// Users
+	// =========================================================================
+
+	usrs, err := userbus.TestSeedUsersWithNoFKs(ctx, 1, userbus.Roles.User, busDomain.User)
+	if err != nil {
+		return apitest.SeedData{}, fmt.Errorf("seeding users: %w", err)
+	}
+	tu1 := apitest.User{
+		User:  usrs[0],
+		Token: apitest.Token(busDomain.User, ath, usrs[0].Email.Address),
+	}
+
+	admins, err := userbus.TestSeedUsersWithNoFKs(ctx, 1, userbus.Roles.Admin, busDomain.User)
+	if err != nil {
+		return apitest.SeedData{}, fmt.Errorf("seeding admins: %w", err)
+	}
+	tu2 := apitest.User{
+		User:  admins[0],
+		Token: apitest.Token(busDomain.User, ath, admins[0].Email.Address),
+	}
+
+	// =========================================================================
+	// Labels — fixed fixture set used by query/update/delete cases
+	// =========================================================================
+
+	labels, err := labelbus.TestSeedLabels(ctx, 4, busDomain.Label)
+	if err != nil {
+		return apitest.SeedData{}, fmt.Errorf("seeding labels: %w", err)
+	}
+
+	// =========================================================================
+	// Permissions — TestSeedTableAccess seeds defaults for both roles, then
+	// the downgrade loop revokes label_catalog access on the non-admin role
+	// so tu1's token returns 403 PermissionDenied for every label endpoint.
+	// =========================================================================
+
+	roles, err := rolebus.TestSeedRoles(ctx, 2, busDomain.Role)
+	if err != nil {
+		return apitest.SeedData{}, fmt.Errorf("seeding roles: %w", err)
+	}
+
+	roleIDs := make([]uuid.UUID, len(roles))
+	for i, r := range roles {
+		roleIDs[i] = r.ID
+	}
+
+	if _, err = userrolebus.TestSeedUserRoles(ctx, []uuid.UUID{tu1.ID, tu2.ID}, roleIDs, busDomain.UserRole); err != nil {
+		return apitest.SeedData{}, fmt.Errorf("seeding user roles: %w", err)
+	}
+
+	if _, err = tableaccessbus.TestSeedTableAccess(ctx, roleIDs, busDomain.TableAccess); err != nil {
+		return apitest.SeedData{}, fmt.Errorf("seeding table access: %w", err)
+	}
+
+	ur1, err := busDomain.UserRole.QueryByUserID(ctx, tu1.ID)
+	if err != nil {
+		return apitest.SeedData{}, fmt.Errorf("querying user1 roles: %w", err)
+	}
+
+	usrRoleIDs := make(uuid.UUIDs, len(ur1))
+	for i, r := range ur1 {
+		usrRoleIDs[i] = r.RoleID
+	}
+
+	tas, err := busDomain.TableAccess.QueryByRoleIDs(ctx, usrRoleIDs)
+	if err != nil {
+		return apitest.SeedData{}, fmt.Errorf("querying table access: %w", err)
+	}
+
+	for _, ta := range tas {
+		if ta.TableName == labelapi.RouteTable {
+			update := tableaccessbus.UpdateTableAccess{
+				CanCreate: dbtest.BoolPointer(false),
+				CanUpdate: dbtest.BoolPointer(false),
+				CanDelete: dbtest.BoolPointer(false),
+				CanRead:   dbtest.BoolPointer(false),
+			}
+			if _, err := busDomain.TableAccess.Update(ctx, ta, update); err != nil {
+				return apitest.SeedData{}, fmt.Errorf("updating table access: %w", err)
+			}
+		}
+	}
+
+	return apitest.SeedData{
+		Admins: []apitest.User{tu2},
+		Users:  []apitest.User{tu1},
+		Labels: labelapp.ToAppLabels(labels),
+	}, nil
+}

--- a/api/cmd/services/ichor/tests/labels/labelapi/update_test.go
+++ b/api/cmd/services/ichor/tests/labels/labelapi/update_test.go
@@ -1,0 +1,159 @@
+package labelapi_test
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
+	"github.com/timmaaaz/ichor/api/sdk/http/apitest"
+	"github.com/timmaaaz/ichor/app/domain/labels/labelapp"
+	"github.com/timmaaaz/ichor/app/sdk/errs"
+	"github.com/timmaaaz/ichor/business/sdk/dbtest"
+)
+
+func update200(sd apitest.SeedData) []apitest.Table {
+	return []apitest.Table{
+		{
+			Name:       "patch-code-and-type",
+			URL:        fmt.Sprintf("/v1/labels/%s", sd.Labels[0].ID),
+			Token:      sd.Admins[0].Token,
+			Method:     http.MethodPut,
+			StatusCode: http.StatusOK,
+			Input: &labelapp.UpdateLabel{
+				Code: dbtest.StringPointer("UPDATED-001"),
+				Type: dbtest.StringPointer("tote"),
+			},
+			GotResp: &labelapp.Label{},
+			ExpResp: &labelapp.Label{
+				ID:          sd.Labels[0].ID,
+				Code:        "UPDATED-001",
+				Type:        "tote",
+				CreatedDate: sd.Labels[0].CreatedDate,
+			},
+			CmpFunc: func(got, exp any) string {
+				return cmp.Diff(got, exp)
+			},
+		},
+		{
+			Name:       "patch-entity-ref-only",
+			URL:        fmt.Sprintf("/v1/labels/%s", sd.Labels[1].ID),
+			Token:      sd.Admins[0].Token,
+			Method:     http.MethodPut,
+			StatusCode: http.StatusOK,
+			Input: &labelapp.UpdateLabel{
+				EntityRef: dbtest.StringPointer("REF-XYZ"),
+			},
+			GotResp: &labelapp.Label{},
+			ExpResp: &labelapp.Label{
+				ID:          sd.Labels[1].ID,
+				Code:        sd.Labels[1].Code,
+				Type:        sd.Labels[1].Type,
+				EntityRef:   "REF-XYZ",
+				CreatedDate: sd.Labels[1].CreatedDate,
+			},
+			CmpFunc: func(got, exp any) string {
+				return cmp.Diff(got, exp)
+			},
+		},
+	}
+}
+
+func update400(sd apitest.SeedData) []apitest.Table {
+	return []apitest.Table{
+		{
+			Name:       "invalid-type",
+			URL:        fmt.Sprintf("/v1/labels/%s", sd.Labels[0].ID),
+			Token:      sd.Admins[0].Token,
+			Method:     http.MethodPut,
+			StatusCode: http.StatusBadRequest,
+			Input: &labelapp.UpdateLabel{
+				Type: dbtest.StringPointer("not_a_valid_type"),
+			},
+			GotResp: &errs.Error{},
+			ExpResp: errs.Newf(errs.InvalidArgument, `validate: [{"field":"type","error":"type must be one of [location tote lot serial product receiving pick]"}]`),
+			CmpFunc: func(got, exp any) string {
+				return cmp.Diff(got, exp)
+			},
+		},
+		{
+			Name:       "bad-uuid",
+			URL:        "/v1/labels/not-a-uuid",
+			Token:      sd.Admins[0].Token,
+			Method:     http.MethodPut,
+			StatusCode: http.StatusBadRequest,
+			Input: &labelapp.UpdateLabel{
+				Code: dbtest.StringPointer("X"),
+			},
+			GotResp: &errs.Error{},
+			ExpResp: errs.Newf(errs.InvalidArgument, "invalid UUID length: 10"),
+			CmpFunc: func(got, exp any) string {
+				return cmp.Diff(got, exp)
+			},
+		},
+	}
+}
+
+func update401(sd apitest.SeedData) []apitest.Table {
+	return []apitest.Table{
+		{
+			Name:       "empty-token",
+			URL:        fmt.Sprintf("/v1/labels/%s", sd.Labels[0].ID),
+			Token:      "&nbsp;",
+			Method:     http.MethodPut,
+			StatusCode: http.StatusUnauthorized,
+			GotResp:    &errs.Error{},
+			ExpResp:    errs.Newf(errs.Unauthenticated, "error parsing token: token contains an invalid number of segments"),
+			CmpFunc: func(got, exp any) string {
+				return cmp.Diff(got, exp)
+			},
+		},
+		{
+			Name:       "bad-sig",
+			URL:        fmt.Sprintf("/v1/labels/%s", sd.Labels[0].ID),
+			Token:      sd.Admins[0].Token + "A",
+			Method:     http.MethodPut,
+			StatusCode: http.StatusUnauthorized,
+			GotResp:    &errs.Error{},
+			ExpResp:    errs.Newf(errs.Unauthenticated, "authentication failed : bindings results[[{[true] map[x:false]}]] ok[true]"),
+			CmpFunc: func(got, exp any) string {
+				return cmp.Diff(got, exp)
+			},
+		},
+		{
+			Name:       "no-update-permission",
+			URL:        fmt.Sprintf("/v1/labels/%s", sd.Labels[0].ID),
+			Token:      sd.Users[0].Token,
+			Method:     http.MethodPut,
+			StatusCode: http.StatusForbidden,
+			Input: &labelapp.UpdateLabel{
+				Code: dbtest.StringPointer("X"),
+			},
+			GotResp: &errs.Error{},
+			ExpResp: errs.Newf(errs.PermissionDenied, "user does not have permission UPDATE for table: inventory.label_catalog"),
+			CmpFunc: func(got, exp any) string {
+				return cmp.Diff(got, exp)
+			},
+		},
+	}
+}
+
+func update404(sd apitest.SeedData) []apitest.Table {
+	return []apitest.Table{
+		{
+			Name:       "not-found",
+			URL:        fmt.Sprintf("/v1/labels/%s", uuid.NewString()),
+			Token:      sd.Admins[0].Token,
+			Method:     http.MethodPut,
+			StatusCode: http.StatusNotFound,
+			Input: &labelapp.UpdateLabel{
+				Code: dbtest.StringPointer("MISSING"),
+			},
+			GotResp: &errs.Error{},
+			ExpResp: errs.Newf(errs.NotFound, "label not found"),
+			CmpFunc: func(got, exp any) string {
+				return cmp.Diff(got, exp)
+			},
+		},
+	}
+}

--- a/api/domain/http/labels/labelapi/filter.go
+++ b/api/domain/http/labels/labelapi/filter.go
@@ -1,0 +1,17 @@
+package labelapi
+
+import (
+	"net/http"
+
+	"github.com/timmaaaz/ichor/app/domain/labels/labelapp"
+)
+
+func parseQueryParams(r *http.Request) (labelapp.QueryParams, error) {
+	values := r.URL.Query()
+	return labelapp.QueryParams{
+		Page:    values.Get("page"),
+		Rows:    values.Get("rows"),
+		OrderBy: values.Get("orderBy"),
+		Type:    values.Get("type"),
+	}, nil
+}

--- a/api/domain/http/labels/labelapi/labelapi.go
+++ b/api/domain/http/labels/labelapi/labelapi.go
@@ -1,0 +1,61 @@
+// Package labelapi exposes HTTP routes for the label subsystem: catalog
+// print, transaction-label render+print, and a type-filtered list query.
+package labelapi
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/timmaaaz/ichor/app/domain/labels/labelapp"
+	"github.com/timmaaaz/ichor/app/sdk/errs"
+	"github.com/timmaaaz/ichor/foundation/web"
+)
+
+type api struct {
+	labelapp *labelapp.App
+}
+
+func newAPI(labelapp *labelapp.App) *api {
+	return &api{labelapp: labelapp}
+}
+
+// print handles POST /v1/labels/print — catalog-label print by ID.
+func (a *api) print(ctx context.Context, r *http.Request) web.Encoder {
+	var req labelapp.PrintRequest
+	if err := web.Decode(r, &req); err != nil {
+		return errs.New(errs.InvalidArgument, err)
+	}
+
+	if err := a.labelapp.Print(ctx, req); err != nil {
+		return errs.NewError(err)
+	}
+	return nil
+}
+
+// renderPrint handles POST /v1/labels/render-print — transaction-label
+// print from an in-memory payload; no catalog row is created.
+func (a *api) renderPrint(ctx context.Context, r *http.Request) web.Encoder {
+	var req labelapp.RenderPrintRequest
+	if err := web.Decode(r, &req); err != nil {
+		return errs.New(errs.InvalidArgument, err)
+	}
+
+	if err := a.labelapp.RenderPrint(ctx, req); err != nil {
+		return errs.NewError(err)
+	}
+	return nil
+}
+
+// query handles GET /v1/labels — type-filtered catalog list for admin UI.
+func (a *api) query(ctx context.Context, r *http.Request) web.Encoder {
+	qp, err := parseQueryParams(r)
+	if err != nil {
+		return errs.New(errs.InvalidArgument, err)
+	}
+
+	labels, err := a.labelapp.Query(ctx, qp)
+	if err != nil {
+		return errs.NewError(err)
+	}
+	return labels
+}

--- a/api/domain/http/labels/labelapi/labelapi.go
+++ b/api/domain/http/labels/labelapi/labelapi.go
@@ -1,11 +1,13 @@
-// Package labelapi exposes HTTP routes for the label subsystem: catalog
-// print, transaction-label render+print, and a type-filtered list query.
+// Package labelapi exposes HTTP routes for the label subsystem: CRUD on
+// the catalog, catalog print, transaction-label render+print, and a
+// type-filtered list query.
 package labelapi
 
 import (
 	"context"
 	"net/http"
 
+	"github.com/google/uuid"
 	"github.com/timmaaaz/ichor/app/domain/labels/labelapp"
 	"github.com/timmaaaz/ichor/app/sdk/errs"
 	"github.com/timmaaaz/ichor/foundation/web"
@@ -17,6 +19,66 @@ type api struct {
 
 func newAPI(labelapp *labelapp.App) *api {
 	return &api{labelapp: labelapp}
+}
+
+// create handles POST /v1/labels — insert a new catalog row.
+func (a *api) create(ctx context.Context, r *http.Request) web.Encoder {
+	var app labelapp.NewLabel
+	if err := web.Decode(r, &app); err != nil {
+		return errs.New(errs.InvalidArgument, err)
+	}
+
+	lc, err := a.labelapp.Create(ctx, app)
+	if err != nil {
+		return errs.NewError(err)
+	}
+	return lc
+}
+
+// update handles PUT /v1/labels/{label_id} — partial patch.
+func (a *api) update(ctx context.Context, r *http.Request) web.Encoder {
+	var app labelapp.UpdateLabel
+	if err := web.Decode(r, &app); err != nil {
+		return errs.New(errs.InvalidArgument, err)
+	}
+
+	id, err := uuid.Parse(web.Param(r, "label_id"))
+	if err != nil {
+		return errs.New(errs.InvalidArgument, err)
+	}
+
+	lc, err := a.labelapp.Update(ctx, id, app)
+	if err != nil {
+		return errs.NewError(err)
+	}
+	return lc
+}
+
+// delete handles DELETE /v1/labels/{label_id}.
+func (a *api) delete(ctx context.Context, r *http.Request) web.Encoder {
+	id, err := uuid.Parse(web.Param(r, "label_id"))
+	if err != nil {
+		return errs.New(errs.InvalidArgument, err)
+	}
+
+	if err := a.labelapp.Delete(ctx, id); err != nil {
+		return errs.NewError(err)
+	}
+	return nil
+}
+
+// queryByID handles GET /v1/labels/{label_id}.
+func (a *api) queryByID(ctx context.Context, r *http.Request) web.Encoder {
+	id, err := uuid.Parse(web.Param(r, "label_id"))
+	if err != nil {
+		return errs.New(errs.InvalidArgument, err)
+	}
+
+	lc, err := a.labelapp.QueryByID(ctx, id)
+	if err != nil {
+		return errs.NewError(err)
+	}
+	return lc
 }
 
 // print handles POST /v1/labels/print — catalog-label print by ID.

--- a/api/domain/http/labels/labelapi/route.go
+++ b/api/domain/http/labels/labelapi/route.go
@@ -5,32 +5,54 @@ import (
 
 	"github.com/timmaaaz/ichor/api/sdk/http/mid"
 	"github.com/timmaaaz/ichor/app/domain/labels/labelapp"
+	"github.com/timmaaaz/ichor/app/sdk/auth"
 	"github.com/timmaaaz/ichor/app/sdk/authclient"
+	"github.com/timmaaaz/ichor/business/domain/core/permissionsbus"
+	"github.com/timmaaaz/ichor/business/domain/labels/labelbus"
 	"github.com/timmaaaz/ichor/foundation/logger"
 	"github.com/timmaaaz/ichor/foundation/web"
 )
 
-// Config holds the dependencies for the label API routes. Matches the
-// shape used by the other app-oriented APIs in this repo (directedworkapi
-// pattern — bus-less, pre-constructed App) because labels do not yet
-// have a permissions/table-access entry.
+// RouteTable is the table_access table name for label catalog authorization.
+// Tests reference this constant when downgrading non-admin role permissions.
+const RouteTable = "inventory.label_catalog"
+
+// Config carries the dependencies for the label API.
 type Config struct {
-	Log        *logger.Logger
-	LabelApp   *labelapp.App
-	AuthClient *authclient.Client
+	Log            *logger.Logger
+	LabelBus       *labelbus.Business
+	AuthClient     *authclient.Client
+	PermissionsBus *permissionsbus.Business
 }
 
-// Routes registers the three label endpoints behind Authenticate. No
-// Authorize middleware is applied at Phase 0b — labels lack a row in
-// core.table_access, and the plan explicitly calls for no role
-// restrictions at this phase.
+// Routes registers every label endpoint behind Authenticate + Authorize. The
+// print and render-print actions are mapped to the Read permission — they
+// dispatch a stored or in-memory label without modifying the catalog, which
+// lets floor workers print without holding catalog-modify rights.
 func Routes(app *web.App, cfg Config) {
 	const version = "v1"
 
 	authen := mid.Authenticate(cfg.AuthClient)
-	api := newAPI(cfg.LabelApp)
+	api := newAPI(labelapp.NewApp(cfg.LabelBus))
 
-	app.HandlerFunc(http.MethodGet, version, "/labels", api.query, authen)
-	app.HandlerFunc(http.MethodPost, version, "/labels/print", api.print, authen)
-	app.HandlerFunc(http.MethodPost, version, "/labels/render-print", api.renderPrint, authen)
+	app.HandlerFunc(http.MethodGet, version, "/labels", api.query, authen,
+		mid.Authorize(cfg.AuthClient, cfg.PermissionsBus, RouteTable, permissionsbus.Actions.Read, auth.RuleAny))
+
+	app.HandlerFunc(http.MethodGet, version, "/labels/{label_id}", api.queryByID, authen,
+		mid.Authorize(cfg.AuthClient, cfg.PermissionsBus, RouteTable, permissionsbus.Actions.Read, auth.RuleAny))
+
+	app.HandlerFunc(http.MethodPost, version, "/labels", api.create, authen,
+		mid.Authorize(cfg.AuthClient, cfg.PermissionsBus, RouteTable, permissionsbus.Actions.Create, auth.RuleAny))
+
+	app.HandlerFunc(http.MethodPut, version, "/labels/{label_id}", api.update, authen,
+		mid.Authorize(cfg.AuthClient, cfg.PermissionsBus, RouteTable, permissionsbus.Actions.Update, auth.RuleAny))
+
+	app.HandlerFunc(http.MethodDelete, version, "/labels/{label_id}", api.delete, authen,
+		mid.Authorize(cfg.AuthClient, cfg.PermissionsBus, RouteTable, permissionsbus.Actions.Delete, auth.RuleAny))
+
+	app.HandlerFunc(http.MethodPost, version, "/labels/print", api.print, authen,
+		mid.Authorize(cfg.AuthClient, cfg.PermissionsBus, RouteTable, permissionsbus.Actions.Read, auth.RuleAny))
+
+	app.HandlerFunc(http.MethodPost, version, "/labels/render-print", api.renderPrint, authen,
+		mid.Authorize(cfg.AuthClient, cfg.PermissionsBus, RouteTable, permissionsbus.Actions.Read, auth.RuleAny))
 }

--- a/api/domain/http/labels/labelapi/route.go
+++ b/api/domain/http/labels/labelapi/route.go
@@ -1,0 +1,36 @@
+package labelapi
+
+import (
+	"net/http"
+
+	"github.com/timmaaaz/ichor/api/sdk/http/mid"
+	"github.com/timmaaaz/ichor/app/domain/labels/labelapp"
+	"github.com/timmaaaz/ichor/app/sdk/authclient"
+	"github.com/timmaaaz/ichor/foundation/logger"
+	"github.com/timmaaaz/ichor/foundation/web"
+)
+
+// Config holds the dependencies for the label API routes. Matches the
+// shape used by the other app-oriented APIs in this repo (directedworkapi
+// pattern — bus-less, pre-constructed App) because labels do not yet
+// have a permissions/table-access entry.
+type Config struct {
+	Log        *logger.Logger
+	LabelApp   *labelapp.App
+	AuthClient *authclient.Client
+}
+
+// Routes registers the three label endpoints behind Authenticate. No
+// Authorize middleware is applied at Phase 0b — labels lack a row in
+// core.table_access, and the plan explicitly calls for no role
+// restrictions at this phase.
+func Routes(app *web.App, cfg Config) {
+	const version = "v1"
+
+	authen := mid.Authenticate(cfg.AuthClient)
+	api := newAPI(cfg.LabelApp)
+
+	app.HandlerFunc(http.MethodGet, version, "/labels", api.query, authen)
+	app.HandlerFunc(http.MethodPost, version, "/labels/print", api.print, authen)
+	app.HandlerFunc(http.MethodPost, version, "/labels/render-print", api.renderPrint, authen)
+}

--- a/api/sdk/http/apitest/apitest.go
+++ b/api/sdk/http/apitest/apitest.go
@@ -34,6 +34,13 @@ func New(db *dbtest.Database, ath *auth.Auth, mux http.Handler) *Test {
 	}
 }
 
+// ServeHTTP exposes the wrapped mux so tests that need direct request
+// inspection (e.g. asserting against an injected printer mid-flow) can
+// drive the same handler chain Run() uses.
+func (at *Test) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	at.mux.ServeHTTP(w, r)
+}
+
 // Run performs the actual test logic based on the table data.
 func (at *Test) Run(t *testing.T, table []Table, testName string) {
 	for _, tt := range table {

--- a/api/sdk/http/apitest/labels.go
+++ b/api/sdk/http/apitest/labels.go
@@ -1,0 +1,107 @@
+package apitest
+
+import (
+	"context"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	authbuild "github.com/timmaaaz/ichor/api/cmd/services/auth/build/all"
+	ichorbuild "github.com/timmaaaz/ichor/api/cmd/services/ichor/build/all"
+	"github.com/timmaaaz/ichor/api/sdk/http/mux"
+	"github.com/timmaaaz/ichor/app/sdk/auth"
+	"github.com/timmaaaz/ichor/app/sdk/authclient"
+	"github.com/timmaaaz/ichor/business/sdk/dbtest"
+)
+
+// RecPrinter is a thread-safe recording implementation of mux.LabelPrinter.
+// Tests inject one via StartLabelTest, exercise label-print routes, and
+// then assert against the recorded ZPL bytes — no TCP, no real printer.
+type RecPrinter struct {
+	mu    sync.Mutex
+	calls [][]byte
+	err   error
+}
+
+// NewRecPrinter constructs a fresh recording printer.
+func NewRecPrinter() *RecPrinter {
+	return &RecPrinter{}
+}
+
+// SendZPL satisfies mux.LabelPrinter. Each successful call appends a copy
+// of the ZPL bytes to the call log so callers can assert on payload shape.
+func (p *RecPrinter) SendZPL(_ context.Context, zpl []byte) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.err != nil {
+		return p.err
+	}
+	cp := make([]byte, len(zpl))
+	copy(cp, zpl)
+	p.calls = append(p.calls, cp)
+	return nil
+}
+
+// SetError installs an error that all subsequent SendZPL calls will return.
+// Use to exercise the printer-failure code path.
+func (p *RecPrinter) SetError(err error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.err = err
+}
+
+// Calls returns a snapshot of the recorded ZPL payloads in dispatch order.
+func (p *RecPrinter) Calls() [][]byte {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([][]byte, len(p.calls))
+	for i, c := range p.calls {
+		cp := make([]byte, len(c))
+		copy(cp, c)
+		out[i] = cp
+	}
+	return out
+}
+
+// Reset clears the call log and any installed error.
+func (p *RecPrinter) Reset() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.calls = nil
+	p.err = nil
+}
+
+// StartLabelTest mirrors StartTest but wires a RecPrinter into the label
+// subsystem so print and render-print integration tests can assert ZPL
+// dispatch without touching real hardware.
+func StartLabelTest(t *testing.T, testName string) (*Test, *RecPrinter) {
+	db := dbtest.NewDatabase(t, testName)
+
+	ath, err := auth.New(auth.Config{
+		Log:       db.Log,
+		DB:        db.DB,
+		KeyLookup: &KeyStore{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	server := httptest.NewServer(mux.WebAPI(mux.Config{
+		Log:  db.Log,
+		Auth: ath,
+		DB:   db.DB,
+	}, authbuild.Routes()))
+
+	authClient := authclient.New(db.Log, server.URL)
+
+	printer := NewRecPrinter()
+
+	mux := mux.WebAPI(mux.Config{
+		Log:          db.Log,
+		AuthClient:   authClient,
+		DB:           db.DB,
+		LabelPrinter: printer,
+	}, ichorbuild.Routes())
+
+	return New(db, ath, mux), printer
+}

--- a/api/sdk/http/apitest/model.go
+++ b/api/sdk/http/apitest/model.go
@@ -34,6 +34,7 @@ import (
 	"github.com/timmaaaz/ichor/app/domain/inventory/inspectionapp"
 	"github.com/timmaaaz/ichor/app/domain/inventory/inventoryadjustmentapp"
 	"github.com/timmaaaz/ichor/app/domain/inventory/inventoryitemapp"
+	"github.com/timmaaaz/ichor/app/domain/labels/labelapp"
 	"github.com/timmaaaz/ichor/app/domain/inventory/inventorylocationapp"
 	"github.com/timmaaaz/ichor/app/domain/inventory/inventorytransactionapp"
 	"github.com/timmaaaz/ichor/app/domain/inventory/lotlocationapp"
@@ -143,6 +144,7 @@ type SeedData struct {
 	PickTasks                   []picktaskapp.PickTask
 	CycleCountSessions          []cyclecountsessionapp.CycleCountSession
 	CycleCountItems             []cyclecountitemapp.CycleCountItem
+	Labels                      labelapp.Labels
 	OrderFulfillmentStatuses    []orderfulfillmentstatusapp.OrderFulfillmentStatus
 	LineItemFulfillmentStatuses []lineitemfulfillmentstatusapp.LineItemFulfillmentStatus
 	Orders                      []ordersapp.Order

--- a/api/sdk/http/mux/mux.go
+++ b/api/sdk/http/mux/mux.go
@@ -65,6 +65,11 @@ type Config struct {
 	ResendAPIKey  string
 	ResendFrom    string
 
+	// Printer holds TCP print target for the label subsystem (Phase 0a/0b).
+	// Empty PrinterIP disables actual network dispatch at wiring time.
+	PrinterIP   string
+	PrinterPort string
+
 	// CORSAllowedOrigins for WebSocket and SSE upgrade routes.
 	// Defaults to "*" if empty (open — set from ICHOR_WEB_CORS_ALLOWED_ORIGINS).
 	CORSAllowedOrigins []string

--- a/api/sdk/http/mux/mux.go
+++ b/api/sdk/http/mux/mux.go
@@ -70,9 +70,22 @@ type Config struct {
 	PrinterIP   string
 	PrinterPort string
 
+	// LabelPrinter is an optional override for the label subsystem's printer.
+	// When non-nil it takes precedence over PrinterIP/PrinterPort and lets
+	// integration tests substitute a recording printer to assert ZPL dispatch
+	// without touching real hardware. Production callers leave it nil.
+	LabelPrinter LabelPrinter
+
 	// CORSAllowedOrigins for WebSocket and SSE upgrade routes.
 	// Defaults to "*" if empty (open — set from ICHOR_WEB_CORS_ALLOWED_ORIGINS).
 	CORSAllowedOrigins []string
+}
+
+// LabelPrinter is the narrow contract for dispatching ZPL bytes. Defined
+// here (instead of importing labelbus.Printer) to keep mux dependency-free
+// from business packages while still letting tests inject a stub.
+type LabelPrinter interface {
+	SendZPL(ctx context.Context, zpl []byte) error
 }
 
 // RouteAdder defines behavior that sets the routes to bind for an instance

--- a/app/domain/labels/labelapp/filter.go
+++ b/app/domain/labels/labelapp/filter.go
@@ -1,0 +1,14 @@
+package labelapp
+
+import (
+	"github.com/timmaaaz/ichor/business/domain/labels/labelbus"
+)
+
+func parseFilter(qp QueryParams) (labelbus.QueryFilter, error) {
+	var filter labelbus.QueryFilter
+	if qp.Type != "" {
+		t := qp.Type
+		filter.Type = &t
+	}
+	return filter, nil
+}

--- a/app/domain/labels/labelapp/labelapp.go
+++ b/app/domain/labels/labelapp/labelapp.go
@@ -76,6 +76,66 @@ func (a *App) RenderPrint(ctx context.Context, req RenderPrintRequest) error {
 	return nil
 }
 
+// Create inserts a new label catalog row.
+func (a *App) Create(ctx context.Context, app NewLabel) (Label, error) {
+	lc, err := a.bus.Create(ctx, toBusNewLabel(app))
+	if err != nil {
+		if errors.Is(err, labelbus.ErrUniqueCode) {
+			return Label{}, errs.New(errs.Aborted, labelbus.ErrUniqueCode)
+		}
+		return Label{}, errs.Newf(errs.Internal, "create: %s", err)
+	}
+	return toAppLabel(lc), nil
+}
+
+// Update applies a partial patch to an existing label.
+func (a *App) Update(ctx context.Context, labelID uuid.UUID, app UpdateLabel) (Label, error) {
+	lc, err := a.bus.QueryByID(ctx, labelID)
+	if err != nil {
+		if errors.Is(err, labelbus.ErrNotFound) {
+			return Label{}, errs.New(errs.NotFound, labelbus.ErrNotFound)
+		}
+		return Label{}, errs.Newf(errs.Internal, "querybyid: %s", err)
+	}
+
+	updated, err := a.bus.Update(ctx, lc, toBusUpdateLabel(app))
+	if err != nil {
+		if errors.Is(err, labelbus.ErrUniqueCode) {
+			return Label{}, errs.New(errs.Aborted, labelbus.ErrUniqueCode)
+		}
+		return Label{}, errs.Newf(errs.Internal, "update: %s", err)
+	}
+	return toAppLabel(updated), nil
+}
+
+// Delete removes a label catalog row.
+func (a *App) Delete(ctx context.Context, labelID uuid.UUID) error {
+	lc, err := a.bus.QueryByID(ctx, labelID)
+	if err != nil {
+		if errors.Is(err, labelbus.ErrNotFound) {
+			return errs.New(errs.NotFound, labelbus.ErrNotFound)
+		}
+		return errs.Newf(errs.Internal, "querybyid: %s", err)
+	}
+
+	if err := a.bus.Delete(ctx, lc); err != nil {
+		return errs.Newf(errs.Internal, "delete: %s", err)
+	}
+	return nil
+}
+
+// QueryByID returns the catalog label with the given ID.
+func (a *App) QueryByID(ctx context.Context, labelID uuid.UUID) (Label, error) {
+	lc, err := a.bus.QueryByID(ctx, labelID)
+	if err != nil {
+		if errors.Is(err, labelbus.ErrNotFound) {
+			return Label{}, errs.New(errs.NotFound, labelbus.ErrNotFound)
+		}
+		return Label{}, errs.Newf(errs.Internal, "querybyid: %s", err)
+	}
+	return toAppLabel(lc), nil
+}
+
 // Query returns catalog labels matching the optional Type filter. No Count
 // call is exposed on the Business yet, so this returns a plain slice with
 // standard pagination.

--- a/app/domain/labels/labelapp/labelapp.go
+++ b/app/domain/labels/labelapp/labelapp.go
@@ -39,12 +39,22 @@ func (a *App) Print(ctx context.Context, req PrintRequest) error {
 		copies = 1
 	}
 
+	lc, err := a.bus.QueryByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, labelbus.ErrNotFound) {
+			return errs.New(errs.NotFound, labelbus.ErrNotFound)
+		}
+		return errs.Newf(errs.Internal, "querybyid label[%s]: %s", id, err)
+	}
+
+	zpl, err := labelbus.Render(lc)
+	if err != nil {
+		return errs.Newf(errs.Internal, "render label[%s]: %s", id, err)
+	}
+
 	for i := 0; i < copies; i++ {
-		if err := a.bus.Print(ctx, id); err != nil {
-			if errors.Is(err, labelbus.ErrNotFound) {
-				return errs.New(errs.NotFound, labelbus.ErrNotFound)
-			}
-			return errs.Newf(errs.Internal, "print label[%s] copy[%d]: %s", id, i+1, err)
+		if err := a.bus.PrintZPL(ctx, zpl); err != nil {
+			return errs.Newf(errs.Internal, "printzpl label[%s] copy[%d]: %s", id, i+1, err)
 		}
 	}
 	return nil

--- a/app/domain/labels/labelapp/labelapp.go
+++ b/app/domain/labels/labelapp/labelapp.go
@@ -1,0 +1,103 @@
+// Package labelapp provides the app-layer orchestration for label catalog
+// lookups, catalog printing (POST /v1/labels/print), and on-the-fly
+// transaction-label printing (POST /v1/labels/render-print). All printing
+// flows through labelbus.Business and the injected Printer.
+package labelapp
+
+import (
+	"context"
+	"errors"
+
+	"github.com/google/uuid"
+	"github.com/timmaaaz/ichor/app/sdk/errs"
+	"github.com/timmaaaz/ichor/business/domain/labels/labelbus"
+	"github.com/timmaaaz/ichor/business/sdk/order"
+	"github.com/timmaaaz/ichor/business/sdk/page"
+)
+
+// App manages the set of app-layer APIs for the label domain.
+type App struct {
+	bus *labelbus.Business
+}
+
+// NewApp constructs a label app API for use.
+func NewApp(bus *labelbus.Business) *App {
+	return &App{bus: bus}
+}
+
+// Print renders the referenced catalog label and dispatches it to the
+// printer. Copies defaults to 1; each copy is a fresh SendZPL call so a
+// dropped connection only loses one label.
+func (a *App) Print(ctx context.Context, req PrintRequest) error {
+	id, err := uuid.Parse(req.LabelID)
+	if err != nil {
+		return errs.Newf(errs.InvalidArgument, "parse label_id: %s", err)
+	}
+
+	copies := req.Copies
+	if copies < 1 {
+		copies = 1
+	}
+
+	for i := 0; i < copies; i++ {
+		if err := a.bus.Print(ctx, id); err != nil {
+			if errors.Is(err, labelbus.ErrNotFound) {
+				return errs.New(errs.NotFound, labelbus.ErrNotFound)
+			}
+			return errs.Newf(errs.Internal, "print label[%s] copy[%d]: %s", id, i+1, err)
+		}
+	}
+	return nil
+}
+
+// RenderPrint renders an ad-hoc payload in-memory (no catalog row, no DB
+// write) and sends it to the printer. Used by transaction-label flows
+// like receiving and pick where each label is unique to a single event.
+func (a *App) RenderPrint(ctx context.Context, req RenderPrintRequest) error {
+	lc := labelbus.LabelCatalog{
+		Type:        req.Type,
+		PayloadJSON: string(req.Payload),
+	}
+	zpl, err := labelbus.Render(lc)
+	if err != nil {
+		return errs.Newf(errs.InvalidArgument, "render: %s", err)
+	}
+
+	copies := req.Copies
+	if copies < 1 {
+		copies = 1
+	}
+
+	for i := 0; i < copies; i++ {
+		if err := a.bus.PrintZPL(ctx, zpl); err != nil {
+			return errs.Newf(errs.Internal, "printzpl copy[%d]: %s", i+1, err)
+		}
+	}
+	return nil
+}
+
+// Query returns catalog labels matching the optional Type filter. No Count
+// call is exposed on the Business yet, so this returns a plain slice with
+// standard pagination.
+func (a *App) Query(ctx context.Context, qp QueryParams) (Labels, error) {
+	pg, err := page.Parse(qp.Page, qp.Rows)
+	if err != nil {
+		return nil, errs.NewFieldsError("page", err)
+	}
+
+	filter, err := parseFilter(qp)
+	if err != nil {
+		return nil, errs.NewFieldsError("filter", err)
+	}
+
+	orderBy, err := order.Parse(orderByFields, qp.OrderBy, defaultOrderBy)
+	if err != nil {
+		return nil, errs.NewFieldsError("orderby", err)
+	}
+
+	labels, err := a.bus.Query(ctx, filter, orderBy, pg)
+	if err != nil {
+		return nil, errs.Newf(errs.Internal, "query: %s", err)
+	}
+	return toAppLabels(labels), nil
+}

--- a/app/domain/labels/labelapp/labelapp_test.go
+++ b/app/domain/labels/labelapp/labelapp_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/timmaaaz/ichor/business/sdk/delegate"
 	"github.com/timmaaaz/ichor/business/sdk/order"
 	"github.com/timmaaaz/ichor/business/sdk/page"
+	"github.com/timmaaaz/ichor/business/sdk/sqldb"
 	"github.com/timmaaaz/ichor/foundation/logger"
 	"github.com/timmaaaz/ichor/foundation/otel"
 )
@@ -28,6 +29,10 @@ type memStorer struct {
 
 func newMemStorer() *memStorer {
 	return &memStorer{rows: map[uuid.UUID]labelbus.LabelCatalog{}}
+}
+
+func (s *memStorer) NewWithTx(tx sqldb.CommitRollbacker) (labelbus.Storer, error) {
+	return s, nil
 }
 
 func (s *memStorer) Create(ctx context.Context, lc labelbus.LabelCatalog) error {

--- a/app/domain/labels/labelapp/labelapp_test.go
+++ b/app/domain/labels/labelapp/labelapp_test.go
@@ -1,0 +1,219 @@
+package labelapp_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/timmaaaz/ichor/app/domain/labels/labelapp"
+	"github.com/timmaaaz/ichor/business/domain/labels/labelbus"
+	"github.com/timmaaaz/ichor/business/sdk/delegate"
+	"github.com/timmaaaz/ichor/business/sdk/order"
+	"github.com/timmaaaz/ichor/business/sdk/page"
+	"github.com/timmaaaz/ichor/foundation/logger"
+	"github.com/timmaaaz/ichor/foundation/otel"
+)
+
+// --- fakes ---
+
+type memStorer struct {
+	mu   sync.Mutex
+	rows map[uuid.UUID]labelbus.LabelCatalog
+}
+
+func newMemStorer() *memStorer {
+	return &memStorer{rows: map[uuid.UUID]labelbus.LabelCatalog{}}
+}
+
+func (s *memStorer) Create(ctx context.Context, lc labelbus.LabelCatalog) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.rows[lc.ID] = lc
+	return nil
+}
+
+func (s *memStorer) Update(ctx context.Context, lc labelbus.LabelCatalog) error {
+	return nil
+}
+func (s *memStorer) Delete(ctx context.Context, lc labelbus.LabelCatalog) error {
+	return nil
+}
+func (s *memStorer) Query(ctx context.Context, _ labelbus.QueryFilter, _ order.By, _ page.Page) ([]labelbus.LabelCatalog, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]labelbus.LabelCatalog, 0, len(s.rows))
+	for _, v := range s.rows {
+		out = append(out, v)
+	}
+	return out, nil
+}
+func (s *memStorer) Count(ctx context.Context, _ labelbus.QueryFilter) (int, error) {
+	return len(s.rows), nil
+}
+func (s *memStorer) QueryByID(ctx context.Context, id uuid.UUID) (labelbus.LabelCatalog, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	lc, ok := s.rows[id]
+	if !ok {
+		return labelbus.LabelCatalog{}, labelbus.ErrNotFound
+	}
+	return lc, nil
+}
+func (s *memStorer) QueryByCode(ctx context.Context, code string) (labelbus.LabelCatalog, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, v := range s.rows {
+		if v.Code == code {
+			return v, nil
+		}
+	}
+	return labelbus.LabelCatalog{}, labelbus.ErrNotFound
+}
+
+type recPrinter struct {
+	mu    sync.Mutex
+	calls [][]byte
+	err   error
+}
+
+func (p *recPrinter) SendZPL(ctx context.Context, zpl []byte) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.err != nil {
+		return p.err
+	}
+	cp := make([]byte, len(zpl))
+	copy(cp, zpl)
+	p.calls = append(p.calls, cp)
+	return nil
+}
+
+// --- helpers ---
+
+func newApp(t *testing.T) (*labelapp.App, *memStorer, *recPrinter) {
+	t.Helper()
+	var buf bytes.Buffer
+	log := logger.New(&buf, logger.LevelInfo, "TEST", func(context.Context) string { return otel.GetTraceID(context.Background()) })
+	store := newMemStorer()
+	printer := &recPrinter{}
+	bus := labelbus.NewBusiness(log, delegate.New(log), store, printer)
+	return labelapp.NewApp(bus), store, printer
+}
+
+// --- tests ---
+
+func Test_Print_CatalogLabel_SingleCopy(t *testing.T) {
+	app, store, printer := newApp(t)
+
+	id := uuid.New()
+	_ = store.Create(context.Background(), labelbus.LabelCatalog{
+		ID: id, Code: "TOTE-001", Type: labelbus.TypeTote,
+	})
+
+	err := app.Print(context.Background(), labelapp.PrintRequest{LabelID: id.String()})
+	if err != nil {
+		t.Fatalf("Print: %v", err)
+	}
+	if len(printer.calls) != 1 {
+		t.Fatalf("expected 1 SendZPL call, got %d", len(printer.calls))
+	}
+	if !bytes.Contains(printer.calls[0], []byte("TOTE-001")) {
+		t.Fatalf("expected ZPL to contain TOTE-001, got: %s", printer.calls[0])
+	}
+}
+
+func Test_Print_CatalogLabel_MultipleCopies(t *testing.T) {
+	app, store, printer := newApp(t)
+
+	id := uuid.New()
+	_ = store.Create(context.Background(), labelbus.LabelCatalog{
+		ID: id, Code: "LOC-A1", Type: labelbus.TypeLocation,
+	})
+
+	err := app.Print(context.Background(), labelapp.PrintRequest{LabelID: id.String(), Copies: 3})
+	if err != nil {
+		t.Fatalf("Print: %v", err)
+	}
+	if len(printer.calls) != 3 {
+		t.Fatalf("expected 3 SendZPL calls, got %d", len(printer.calls))
+	}
+}
+
+func Test_Print_NotFound(t *testing.T) {
+	app, _, printer := newApp(t)
+
+	err := app.Print(context.Background(), labelapp.PrintRequest{LabelID: uuid.New().String()})
+	if err == nil {
+		t.Fatal("expected error for missing label, got nil")
+	}
+	if len(printer.calls) != 0 {
+		t.Fatalf("printer should not be called on not-found, got %d calls", len(printer.calls))
+	}
+}
+
+func Test_Print_BadUUID(t *testing.T) {
+	app, _, _ := newApp(t)
+	if err := app.Print(context.Background(), labelapp.PrintRequest{LabelID: "not-a-uuid"}); err == nil {
+		t.Fatal("expected error for bad uuid, got nil")
+	}
+}
+
+func Test_Print_PrinterError(t *testing.T) {
+	app, store, printer := newApp(t)
+	printer.err = errors.New("boom")
+
+	id := uuid.New()
+	_ = store.Create(context.Background(), labelbus.LabelCatalog{
+		ID: id, Code: "X", Type: labelbus.TypeTote,
+	})
+
+	if err := app.Print(context.Background(), labelapp.PrintRequest{LabelID: id.String()}); err == nil {
+		t.Fatal("expected printer error to surface, got nil")
+	}
+}
+
+func Test_RenderPrint_Receiving(t *testing.T) {
+	app, _, printer := newApp(t)
+
+	payload := map[string]any{
+		"productName": "Widget",
+		"sku":         "SKU-1",
+		"upc":         "012345678905",
+		"lotNumber":   nil,
+		"expiryDate":  nil,
+		"quantity":    10,
+		"poNumber":    "PO-42",
+	}
+	raw, _ := json.Marshal(payload)
+
+	err := app.RenderPrint(context.Background(), labelapp.RenderPrintRequest{
+		Type:    labelbus.TypeReceiving,
+		Payload: raw,
+		Copies:  2,
+	})
+	if err != nil {
+		t.Fatalf("RenderPrint: %v", err)
+	}
+	if len(printer.calls) != 2 {
+		t.Fatalf("expected 2 SendZPL calls, got %d", len(printer.calls))
+	}
+	if !strings.Contains(string(printer.calls[0]), "PO-42") {
+		t.Fatalf("expected ZPL to contain PO-42, got: %s", printer.calls[0])
+	}
+}
+
+func Test_RenderPrint_BadType(t *testing.T) {
+	app, _, _ := newApp(t)
+	err := app.RenderPrint(context.Background(), labelapp.RenderPrintRequest{
+		Type:    "nonsense",
+		Payload: json.RawMessage(`{}`),
+	})
+	if err == nil {
+		t.Fatal("expected error for unknown type, got nil")
+	}
+}

--- a/app/domain/labels/labelapp/model.go
+++ b/app/domain/labels/labelapp/model.go
@@ -1,0 +1,108 @@
+package labelapp
+
+import (
+	"encoding/json"
+
+	"github.com/timmaaaz/ichor/app/sdk/errs"
+	"github.com/timmaaaz/ichor/business/domain/labels/labelbus"
+	"github.com/timmaaaz/ichor/foundation/timeutil"
+)
+
+// QueryParams filters catalog labels via the list endpoint.
+type QueryParams struct {
+	Page    string
+	Rows    string
+	OrderBy string
+	Type    string
+}
+
+// Label is the API-facing shape of a catalog label.
+type Label struct {
+	ID          string `json:"id"`
+	Code        string `json:"code"`
+	Type        string `json:"type"`
+	EntityRef   string `json:"entity_ref,omitempty"`
+	PayloadJSON string `json:"payload_json,omitempty"`
+	CreatedDate string `json:"created_date"`
+}
+
+// Encode implements the web.Encoder interface.
+func (app Label) Encode() ([]byte, string, error) {
+	data, err := json.Marshal(app)
+	return data, "application/json", err
+}
+
+// Labels is a slice wrapper so it implements web.Encoder directly.
+type Labels []Label
+
+// Encode implements the web.Encoder interface.
+func (app Labels) Encode() ([]byte, string, error) {
+	data, err := json.Marshal(app)
+	return data, "application/json", err
+}
+
+func toAppLabel(bus labelbus.LabelCatalog) Label {
+	return Label{
+		ID:          bus.ID.String(),
+		Code:        bus.Code,
+		Type:        bus.Type,
+		EntityRef:   bus.EntityRef,
+		PayloadJSON: bus.PayloadJSON,
+		CreatedDate: bus.CreatedDate.Format(timeutil.FORMAT),
+	}
+}
+
+func toAppLabels(bus []labelbus.LabelCatalog) Labels {
+	out := make(Labels, len(bus))
+	for i, v := range bus {
+		out[i] = toAppLabel(v)
+	}
+	return out
+}
+
+// =============================================================================
+
+// PrintRequest is the body of POST /v1/labels/print. A catalog label row is
+// looked up by LabelID, rendered to ZPL, and dispatched to the printer.
+type PrintRequest struct {
+	LabelID string `json:"label_id" validate:"required,min=36,max=36"`
+	Copies  int    `json:"copies,omitempty" validate:"omitempty,min=1,max=100"`
+}
+
+// Decode implements the decoder interface.
+func (app *PrintRequest) Decode(data []byte) error {
+	return json.Unmarshal(data, &app)
+}
+
+// Validate checks the data in the model is considered clean.
+func (app PrintRequest) Validate() error {
+	if err := errs.Check(app); err != nil {
+		return errs.Newf(errs.InvalidArgument, "validate: %s", err)
+	}
+	return nil
+}
+
+// RenderPrintRequest is the body of POST /v1/labels/render-print. A
+// transaction-label payload is rendered in-memory and dispatched to the
+// printer — no catalog row, no DB write.
+type RenderPrintRequest struct {
+	Type    string          `json:"type" validate:"required,oneof=receiving pick"`
+	Payload json.RawMessage `json:"payload" validate:"required"`
+	Copies  int             `json:"copies,omitempty" validate:"omitempty,min=1,max=100"`
+}
+
+// Decode implements the decoder interface.
+func (app *RenderPrintRequest) Decode(data []byte) error {
+	return json.Unmarshal(data, &app)
+}
+
+// Validate checks the data in the model is considered clean.
+func (app RenderPrintRequest) Validate() error {
+	if err := errs.Check(app); err != nil {
+		return errs.Newf(errs.InvalidArgument, "validate: %s", err)
+	}
+	if len(app.Payload) == 0 {
+		return errs.Newf(errs.InvalidArgument, "validate: payload is empty")
+	}
+	return nil
+}

--- a/app/domain/labels/labelapp/model.go
+++ b/app/domain/labels/labelapp/model.go
@@ -96,6 +96,13 @@ func (app *RenderPrintRequest) Decode(data []byte) error {
 	return json.Unmarshal(data, &app)
 }
 
+// maxRenderPayloadBytes caps the raw JSON payload accepted by the
+// render-print endpoint. Realistic label payloads (pick with 100
+// serial numbers + long names) are ~3KB; 64KB gives generous headroom
+// while preventing an authenticated client from POSTing a multi-MB
+// body through the validate:"required" tag alone.
+const maxRenderPayloadBytes = 64 * 1024
+
 // Validate checks the data in the model is considered clean.
 func (app RenderPrintRequest) Validate() error {
 	if err := errs.Check(app); err != nil {
@@ -103,6 +110,9 @@ func (app RenderPrintRequest) Validate() error {
 	}
 	if len(app.Payload) == 0 {
 		return errs.Newf(errs.InvalidArgument, "validate: payload is empty")
+	}
+	if len(app.Payload) > maxRenderPayloadBytes {
+		return errs.Newf(errs.InvalidArgument, "validate: payload exceeds %d bytes", maxRenderPayloadBytes)
 	}
 	return nil
 }

--- a/app/domain/labels/labelapp/model.go
+++ b/app/domain/labels/labelapp/model.go
@@ -70,7 +70,7 @@ func ToAppLabels(bus []labelbus.LabelCatalog) Labels {
 
 // NewLabel is the input shape for POST /v1/labels (catalog row creation).
 type NewLabel struct {
-	Code        string `json:"code" validate:"required,min=1,max=64"`
+	Code        string `json:"code" validate:"required,min=1,max=32"`
 	Type        string `json:"type" validate:"required,oneof=location tote lot serial product receiving pick"`
 	EntityRef   string `json:"entity_ref,omitempty" validate:"omitempty,max=128"`
 	PayloadJSON string `json:"payload_json,omitempty"`
@@ -100,7 +100,7 @@ func toBusNewLabel(app NewLabel) labelbus.NewLabelCatalog {
 
 // UpdateLabel carries optional patch fields for PUT /v1/labels/{label_id}.
 type UpdateLabel struct {
-	Code        *string `json:"code,omitempty" validate:"omitempty,min=1,max=64"`
+	Code        *string `json:"code,omitempty" validate:"omitempty,min=1,max=32"`
 	Type        *string `json:"type,omitempty" validate:"omitempty,oneof=location tote lot serial product receiving pick"`
 	EntityRef   *string `json:"entity_ref,omitempty" validate:"omitempty,max=128"`
 	PayloadJSON *string `json:"payload_json,omitempty"`

--- a/app/domain/labels/labelapp/model.go
+++ b/app/domain/labels/labelapp/model.go
@@ -60,6 +60,74 @@ func toAppLabels(bus []labelbus.LabelCatalog) Labels {
 	return out
 }
 
+// ToAppLabels exposes the internal slice converter so seed harnesses can
+// pre-shape integration test fixtures.
+func ToAppLabels(bus []labelbus.LabelCatalog) Labels {
+	return toAppLabels(bus)
+}
+
+// =============================================================================
+
+// NewLabel is the input shape for POST /v1/labels (catalog row creation).
+type NewLabel struct {
+	Code        string `json:"code" validate:"required,min=1,max=64"`
+	Type        string `json:"type" validate:"required,oneof=location tote lot serial product receiving pick"`
+	EntityRef   string `json:"entity_ref,omitempty" validate:"omitempty,max=128"`
+	PayloadJSON string `json:"payload_json,omitempty"`
+}
+
+// Decode implements the decoder interface.
+func (app *NewLabel) Decode(data []byte) error {
+	return json.Unmarshal(data, &app)
+}
+
+// Validate checks that the new label is well-formed.
+func (app NewLabel) Validate() error {
+	if err := errs.Check(app); err != nil {
+		return errs.Newf(errs.InvalidArgument, "validate: %s", err)
+	}
+	return nil
+}
+
+func toBusNewLabel(app NewLabel) labelbus.NewLabelCatalog {
+	return labelbus.NewLabelCatalog{
+		Code:        app.Code,
+		Type:        app.Type,
+		EntityRef:   app.EntityRef,
+		PayloadJSON: app.PayloadJSON,
+	}
+}
+
+// UpdateLabel carries optional patch fields for PUT /v1/labels/{label_id}.
+type UpdateLabel struct {
+	Code        *string `json:"code,omitempty" validate:"omitempty,min=1,max=64"`
+	Type        *string `json:"type,omitempty" validate:"omitempty,oneof=location tote lot serial product receiving pick"`
+	EntityRef   *string `json:"entity_ref,omitempty" validate:"omitempty,max=128"`
+	PayloadJSON *string `json:"payload_json,omitempty"`
+}
+
+// Decode implements the decoder interface.
+func (app *UpdateLabel) Decode(data []byte) error {
+	return json.Unmarshal(data, &app)
+}
+
+// Validate checks the data in the model is considered clean.
+func (app UpdateLabel) Validate() error {
+	if err := errs.Check(app); err != nil {
+		return errs.Newf(errs.InvalidArgument, "validate: %s", err)
+	}
+	return nil
+}
+
+func toBusUpdateLabel(app UpdateLabel) labelbus.UpdateLabelCatalog {
+	return labelbus.UpdateLabelCatalog{
+		Code:        app.Code,
+		Type:        app.Type,
+		EntityRef:   app.EntityRef,
+		PayloadJSON: app.PayloadJSON,
+	}
+}
+
 // =============================================================================
 
 // PrintRequest is the body of POST /v1/labels/print. A catalog label row is

--- a/app/domain/labels/labelapp/order.go
+++ b/app/domain/labels/labelapp/order.go
@@ -1,0 +1,15 @@
+package labelapp
+
+import (
+	"github.com/timmaaaz/ichor/business/domain/labels/labelbus"
+	"github.com/timmaaaz/ichor/business/sdk/order"
+)
+
+var defaultOrderBy = order.NewBy(labelbus.OrderByCode, order.ASC)
+
+var orderByFields = map[string]string{
+	"id":           labelbus.OrderByID,
+	"code":         labelbus.OrderByCode,
+	"type":         labelbus.OrderByType,
+	"created_date": labelbus.OrderByCreatedDate,
+}

--- a/app/domain/labels/labelapp/validate_test.go
+++ b/app/domain/labels/labelapp/validate_test.go
@@ -1,0 +1,44 @@
+package labelapp_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/timmaaaz/ichor/app/domain/labels/labelapp"
+	"github.com/timmaaaz/ichor/business/domain/labels/labelbus"
+)
+
+func Test_RenderPrintRequest_Validate_PayloadTooLarge(t *testing.T) {
+	// Build a JSON payload > 64KB.
+	big := strings.Repeat("a", 70*1024)
+	raw, err := json.Marshal(map[string]string{"junk": big})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	req := labelapp.RenderPrintRequest{
+		Type:    labelbus.TypeReceiving,
+		Payload: raw,
+	}
+	if err := req.Validate(); err == nil {
+		t.Fatal("expected validation error for oversize payload, got nil")
+	}
+}
+
+func Test_RenderPrintRequest_Validate_PayloadAtCap(t *testing.T) {
+	// Payload just under the cap should validate.
+	big := strings.Repeat("a", 60*1024)
+	raw, err := json.Marshal(map[string]string{"junk": big})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	req := labelapp.RenderPrintRequest{
+		Type:    labelbus.TypeReceiving,
+		Payload: raw,
+	}
+	if err := req.Validate(); err != nil {
+		t.Fatalf("expected payload under cap to validate, got: %v", err)
+	}
+}

--- a/business/domain/core/tableaccessbus/testutil.go
+++ b/business/domain/core/tableaccessbus/testutil.go
@@ -80,6 +80,7 @@ func TestSeedTableAccess(ctx context.Context, roleIDs uuid.UUIDs, api *Business)
 		{RoleID: uuid.Nil, TableName: "inventory.pick_tasks", CanCreate: true, CanRead: true, CanUpdate: true, CanDelete: true},
 		{RoleID: uuid.Nil, TableName: "inventory.cycle_count_sessions", CanCreate: true, CanRead: true, CanUpdate: true, CanDelete: true},
 		{RoleID: uuid.Nil, TableName: "inventory.cycle_count_items", CanCreate: true, CanRead: true, CanUpdate: true, CanDelete: true},
+		{RoleID: uuid.Nil, TableName: "inventory.label_catalog", CanCreate: true, CanRead: true, CanUpdate: true, CanDelete: true},
 
 		// Procurement schema
 		{RoleID: uuid.Nil, TableName: "procurement.suppliers", CanCreate: true, CanRead: true, CanUpdate: true, CanDelete: true},

--- a/business/domain/labels/labelbus/event.go
+++ b/business/domain/labels/labelbus/event.go
@@ -1,3 +1,135 @@
 package labelbus
 
-// Events may be published here in a later phase (label_jobs audit, Phase 2).
+import (
+	"encoding/json"
+
+	"github.com/google/uuid"
+	"github.com/timmaaaz/ichor/business/sdk/delegate"
+)
+
+// DomainName represents the name of this domain for delegate events.
+const DomainName = "label"
+
+// EntityName is the workflow entity name used for event matching.
+// Must match the entity name in workflow.entities (the bare table
+// name, not schema-qualified).
+const EntityName = "label_catalog"
+
+// Delegate action constants.
+const (
+	ActionCreated = "created"
+	ActionUpdated = "updated"
+	ActionDeleted = "deleted"
+)
+
+// =============================================================================
+// Created Event
+// =============================================================================
+
+// ActionCreatedParms represents the parameters for the created action.
+// LabelCatalog is a reference/lookup table without user tracking fields,
+// so UserID is set to uuid.Nil (matches pagebus/rolebus convention).
+type ActionCreatedParms struct {
+	EntityID uuid.UUID    `json:"entityID"`
+	UserID   uuid.UUID    `json:"userID"`
+	Entity   LabelCatalog `json:"entity"`
+}
+
+// Marshal returns the event parameters encoded as JSON.
+func (p *ActionCreatedParms) Marshal() ([]byte, error) {
+	return json.Marshal(p)
+}
+
+// ActionCreatedData constructs delegate data for label creation events.
+func ActionCreatedData(lc LabelCatalog) delegate.Data {
+	params := ActionCreatedParms{
+		EntityID: lc.ID,
+		UserID:   uuid.Nil,
+		Entity:   lc,
+	}
+
+	rawParams, err := params.Marshal()
+	if err != nil {
+		panic(err)
+	}
+
+	return delegate.Data{
+		Domain:    DomainName,
+		Action:    ActionCreated,
+		RawParams: rawParams,
+	}
+}
+
+// =============================================================================
+// Updated Event
+// =============================================================================
+
+// ActionUpdatedParms represents the parameters for the updated action.
+type ActionUpdatedParms struct {
+	EntityID     uuid.UUID    `json:"entityID"`
+	UserID       uuid.UUID    `json:"userID"`
+	Entity       LabelCatalog `json:"entity"`
+	BeforeEntity LabelCatalog `json:"beforeEntity,omitempty"`
+}
+
+// Marshal returns the event parameters encoded as JSON.
+func (p *ActionUpdatedParms) Marshal() ([]byte, error) {
+	return json.Marshal(p)
+}
+
+// ActionUpdatedData constructs delegate data for label update events.
+func ActionUpdatedData(before, after LabelCatalog) delegate.Data {
+	params := ActionUpdatedParms{
+		EntityID:     after.ID,
+		UserID:       uuid.Nil,
+		Entity:       after,
+		BeforeEntity: before,
+	}
+
+	rawParams, err := params.Marshal()
+	if err != nil {
+		panic(err)
+	}
+
+	return delegate.Data{
+		Domain:    DomainName,
+		Action:    ActionUpdated,
+		RawParams: rawParams,
+	}
+}
+
+// =============================================================================
+// Deleted Event
+// =============================================================================
+
+// ActionDeletedParms represents the parameters for the deleted action.
+type ActionDeletedParms struct {
+	EntityID uuid.UUID    `json:"entityID"`
+	UserID   uuid.UUID    `json:"userID"`
+	Entity   LabelCatalog `json:"entity"`
+}
+
+// Marshal returns the event parameters encoded as JSON.
+func (p *ActionDeletedParms) Marshal() ([]byte, error) {
+	return json.Marshal(p)
+}
+
+// ActionDeletedData constructs delegate data for label deletion events.
+func ActionDeletedData(lc LabelCatalog) delegate.Data {
+	params := ActionDeletedParms{
+		EntityID: lc.ID,
+		UserID:   uuid.Nil,
+		Entity:   lc,
+	}
+
+	rawParams, err := params.Marshal()
+	if err != nil {
+		panic(err)
+	}
+
+	return delegate.Data{
+		Domain:    DomainName,
+		Action:    ActionDeleted,
+		RawParams: rawParams,
+	}
+}

--- a/business/domain/labels/labelbus/event.go
+++ b/business/domain/labels/labelbus/event.go
@@ -1,0 +1,3 @@
+package labelbus
+
+// Events may be published here in a later phase (label_jobs audit, Phase 2).

--- a/business/domain/labels/labelbus/filter.go
+++ b/business/domain/labels/labelbus/filter.go
@@ -1,0 +1,10 @@
+package labelbus
+
+import "github.com/google/uuid"
+
+// QueryFilter holds the available fields for label catalog queries.
+type QueryFilter struct {
+	ID   *uuid.UUID
+	Code *string
+	Type *string
+}

--- a/business/domain/labels/labelbus/labelbus.go
+++ b/business/domain/labels/labelbus/labelbus.go
@@ -11,6 +11,7 @@ import (
 	"github.com/timmaaaz/ichor/business/sdk/delegate"
 	"github.com/timmaaaz/ichor/business/sdk/order"
 	"github.com/timmaaaz/ichor/business/sdk/page"
+	"github.com/timmaaaz/ichor/business/sdk/sqldb"
 	"github.com/timmaaaz/ichor/foundation/logger"
 )
 
@@ -22,6 +23,7 @@ var (
 
 // Storer declares the behavior needed to persist and retrieve label catalog entries.
 type Storer interface {
+	NewWithTx(tx sqldb.CommitRollbacker) (Storer, error)
 	Create(ctx context.Context, lc LabelCatalog) error
 	Update(ctx context.Context, lc LabelCatalog) error
 	Delete(ctx context.Context, lc LabelCatalog) error
@@ -47,6 +49,22 @@ type Business struct {
 // NewBusiness constructs a label business API for use.
 func NewBusiness(log *logger.Logger, d *delegate.Delegate, storer Storer, printer Printer) *Business {
 	return &Business{log: log, delegate: d, storer: storer, printer: printer}
+}
+
+// NewWithTx constructs a new Business value replacing the Storer value with
+// a Storer value that is currently inside a transaction.
+func (b *Business) NewWithTx(tx sqldb.CommitRollbacker) (*Business, error) {
+	storer, err := b.storer.NewWithTx(tx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Business{
+		log:      b.log,
+		delegate: b.delegate,
+		storer:   storer,
+		printer:  b.printer,
+	}, nil
 }
 
 // Create inserts a new label into the catalog.

--- a/business/domain/labels/labelbus/labelbus.go
+++ b/business/domain/labels/labelbus/labelbus.go
@@ -109,3 +109,16 @@ func (b *Business) PrintZPL(ctx context.Context, zpl []byte) error {
 	b.log.Info(ctx, "transaction label printed", "bytes", len(zpl))
 	return nil
 }
+
+// SeedCreate inserts a fully-formed LabelCatalog (caller supplies the ID).
+// Seed-only — preserves deterministic UUIDs across reseeds. bus.Create
+// assigns uuid.New internally, which would break determinism.
+func (b *Business) SeedCreate(ctx context.Context, lc LabelCatalog) error {
+	if lc.CreatedDate.IsZero() {
+		lc.CreatedDate = time.Now()
+	}
+	if err := b.storer.Create(ctx, lc); err != nil {
+		return fmt.Errorf("seedcreate: %w", err)
+	}
+	return nil
+}

--- a/business/domain/labels/labelbus/labelbus.go
+++ b/business/domain/labels/labelbus/labelbus.go
@@ -62,6 +62,14 @@ func (b *Business) Create(ctx context.Context, nlc NewLabelCatalog) (LabelCatalo
 	if err := b.storer.Create(ctx, lc); err != nil {
 		return LabelCatalog{}, fmt.Errorf("create: %w", err)
 	}
+
+	// Fire delegate event for workflow automation. Errors are logged
+	// but not returned — the DB write already succeeded and the caller
+	// has a valid LabelCatalog back.
+	if err := b.delegate.Call(ctx, ActionCreatedData(lc)); err != nil {
+		b.log.Error(ctx, "labelbus: delegate call failed", "action", ActionCreated, "err", err)
+	}
+
 	return lc, nil
 }
 

--- a/business/domain/labels/labelbus/labelbus.go
+++ b/business/domain/labels/labelbus/labelbus.go
@@ -1,0 +1,111 @@
+// Package labelbus provides business access to label catalog and printing.
+package labelbus
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/timmaaaz/ichor/business/sdk/delegate"
+	"github.com/timmaaaz/ichor/business/sdk/order"
+	"github.com/timmaaaz/ichor/business/sdk/page"
+	"github.com/timmaaaz/ichor/foundation/logger"
+)
+
+// Set of error variables for CRUD operations.
+var (
+	ErrNotFound   = errors.New("label not found")
+	ErrUniqueCode = errors.New("label code already exists")
+)
+
+// Storer declares the behavior needed to persist and retrieve label catalog entries.
+type Storer interface {
+	Create(ctx context.Context, lc LabelCatalog) error
+	Update(ctx context.Context, lc LabelCatalog) error
+	Delete(ctx context.Context, lc LabelCatalog) error
+	Query(ctx context.Context, filter QueryFilter, orderBy order.By, page page.Page) ([]LabelCatalog, error)
+	Count(ctx context.Context, filter QueryFilter) (int, error)
+	QueryByID(ctx context.Context, id uuid.UUID) (LabelCatalog, error)
+	QueryByCode(ctx context.Context, code string) (LabelCatalog, error)
+}
+
+// Printer declares the behavior for sending ZPL bytes to a physical printer.
+type Printer interface {
+	SendZPL(ctx context.Context, zpl []byte) error
+}
+
+// Business manages the set of APIs for label access.
+type Business struct {
+	log      *logger.Logger
+	delegate *delegate.Delegate
+	storer   Storer
+	printer  Printer
+}
+
+// NewBusiness constructs a label business API for use.
+func NewBusiness(log *logger.Logger, d *delegate.Delegate, storer Storer, printer Printer) *Business {
+	return &Business{log: log, delegate: d, storer: storer, printer: printer}
+}
+
+// Create inserts a new label into the catalog.
+func (b *Business) Create(ctx context.Context, nlc NewLabelCatalog) (LabelCatalog, error) {
+	lc := LabelCatalog{
+		ID:          uuid.New(),
+		Code:        nlc.Code,
+		Type:        nlc.Type,
+		EntityRef:   nlc.EntityRef,
+		PayloadJSON: nlc.PayloadJSON,
+		CreatedDate: time.Now(),
+	}
+	if err := b.storer.Create(ctx, lc); err != nil {
+		return LabelCatalog{}, fmt.Errorf("create: %w", err)
+	}
+	return lc, nil
+}
+
+// QueryByCode retrieves a label by its stable code.
+func (b *Business) QueryByCode(ctx context.Context, code string) (LabelCatalog, error) {
+	lc, err := b.storer.QueryByCode(ctx, code)
+	if err != nil {
+		return LabelCatalog{}, fmt.Errorf("querybycode: %w", err)
+	}
+	return lc, nil
+}
+
+// Query retrieves a page of labels matching the filter.
+func (b *Business) Query(ctx context.Context, filter QueryFilter, orderBy order.By, pg page.Page) ([]LabelCatalog, error) {
+	labels, err := b.storer.Query(ctx, filter, orderBy, pg)
+	if err != nil {
+		return nil, fmt.Errorf("query: %w", err)
+	}
+	return labels, nil
+}
+
+// Print renders ZPL for the given catalog label id and sends it to the printer.
+func (b *Business) Print(ctx context.Context, id uuid.UUID) error {
+	lc, err := b.storer.QueryByID(ctx, id)
+	if err != nil {
+		return fmt.Errorf("querybyid: %w", err)
+	}
+	zpl, err := Render(lc)
+	if err != nil {
+		return fmt.Errorf("render: %w", err)
+	}
+	if err := b.printer.SendZPL(ctx, zpl); err != nil {
+		return fmt.Errorf("sendzpl: %w", err)
+	}
+	b.log.Info(ctx, "label printed", "code", lc.Code, "bytes", len(zpl))
+	return nil
+}
+
+// PrintZPL sends pre-rendered ZPL bytes directly to the printer. Used by
+// transaction-label flows (render-print endpoint) that skip label_catalog.
+func (b *Business) PrintZPL(ctx context.Context, zpl []byte) error {
+	if err := b.printer.SendZPL(ctx, zpl); err != nil {
+		return fmt.Errorf("sendzpl: %w", err)
+	}
+	b.log.Info(ctx, "transaction label printed", "bytes", len(zpl))
+	return nil
+}

--- a/business/domain/labels/labelbus/labelbus.go
+++ b/business/domain/labels/labelbus/labelbus.go
@@ -73,6 +73,56 @@ func (b *Business) Create(ctx context.Context, nlc NewLabelCatalog) (LabelCatalo
 	return lc, nil
 }
 
+// Update applies a partial patch to an existing label and persists it.
+func (b *Business) Update(ctx context.Context, lc LabelCatalog, ulc UpdateLabelCatalog) (LabelCatalog, error) {
+	before := lc
+
+	if ulc.Code != nil {
+		lc.Code = *ulc.Code
+	}
+	if ulc.Type != nil {
+		lc.Type = *ulc.Type
+	}
+	if ulc.EntityRef != nil {
+		lc.EntityRef = *ulc.EntityRef
+	}
+	if ulc.PayloadJSON != nil {
+		lc.PayloadJSON = *ulc.PayloadJSON
+	}
+
+	if err := b.storer.Update(ctx, lc); err != nil {
+		return LabelCatalog{}, fmt.Errorf("update: %w", err)
+	}
+
+	if err := b.delegate.Call(ctx, ActionUpdatedData(before, lc)); err != nil {
+		b.log.Error(ctx, "labelbus: delegate call failed", "action", ActionUpdated, "err", err)
+	}
+
+	return lc, nil
+}
+
+// Delete removes a label from the catalog.
+func (b *Business) Delete(ctx context.Context, lc LabelCatalog) error {
+	if err := b.storer.Delete(ctx, lc); err != nil {
+		return fmt.Errorf("delete: %w", err)
+	}
+
+	if err := b.delegate.Call(ctx, ActionDeletedData(lc)); err != nil {
+		b.log.Error(ctx, "labelbus: delegate call failed", "action", ActionDeleted, "err", err)
+	}
+
+	return nil
+}
+
+// QueryByID retrieves a label by its ID.
+func (b *Business) QueryByID(ctx context.Context, id uuid.UUID) (LabelCatalog, error) {
+	lc, err := b.storer.QueryByID(ctx, id)
+	if err != nil {
+		return LabelCatalog{}, fmt.Errorf("querybyid: %w", err)
+	}
+	return lc, nil
+}
+
 // QueryByCode retrieves a label by its stable code.
 func (b *Business) QueryByCode(ctx context.Context, code string) (LabelCatalog, error) {
 	lc, err := b.storer.QueryByCode(ctx, code)
@@ -80,6 +130,15 @@ func (b *Business) QueryByCode(ctx context.Context, code string) (LabelCatalog, 
 		return LabelCatalog{}, fmt.Errorf("querybycode: %w", err)
 	}
 	return lc, nil
+}
+
+// Count returns the number of labels matching the filter.
+func (b *Business) Count(ctx context.Context, filter QueryFilter) (int, error) {
+	count, err := b.storer.Count(ctx, filter)
+	if err != nil {
+		return 0, fmt.Errorf("count: %w", err)
+	}
+	return count, nil
 }
 
 // Query retrieves a page of labels matching the filter.

--- a/business/domain/labels/labelbus/labelbus_test.go
+++ b/business/domain/labels/labelbus/labelbus_test.go
@@ -1,0 +1,21 @@
+package labelbus_test
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/timmaaaz/ichor/business/domain/labels/labelbus"
+	"github.com/timmaaaz/ichor/business/sdk/delegate"
+	"github.com/timmaaaz/ichor/foundation/logger"
+	"github.com/timmaaaz/ichor/foundation/otel"
+)
+
+func Test_NewBusiness(t *testing.T) {
+	var buf bytes.Buffer
+	log := logger.New(&buf, logger.LevelInfo, "TEST", func(context.Context) string { return otel.GetTraceID(context.Background()) })
+	bus := labelbus.NewBusiness(log, delegate.New(log), nil, nil)
+	if bus == nil {
+		t.Fatalf("NewBusiness returned nil")
+	}
+}

--- a/business/domain/labels/labelbus/labelbus_test.go
+++ b/business/domain/labels/labelbus/labelbus_test.go
@@ -3,6 +3,7 @@ package labelbus_test
 import (
 	"bytes"
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/timmaaaz/ichor/business/domain/labels/labelbus"
@@ -17,5 +18,51 @@ func Test_NewBusiness(t *testing.T) {
 	bus := labelbus.NewBusiness(log, delegate.New(log), nil, nil)
 	if bus == nil {
 		t.Fatalf("NewBusiness returned nil")
+	}
+}
+
+func Test_Render_DispatchesByType(t *testing.T) {
+	tests := []struct {
+		name string
+		lc   labelbus.LabelCatalog
+		want string
+	}{
+		{"tote", labelbus.LabelCatalog{Code: "TOTE-001", Type: labelbus.TypeTote}, "TOTE-001"},
+		{"location", labelbus.LabelCatalog{Code: "STG-A01", Type: labelbus.TypeLocation}, "STG-A01"},
+		{"receiving", labelbus.LabelCatalog{
+			Code: "RX-1", Type: labelbus.TypeReceiving,
+			PayloadJSON: `{"productName":"Widget","sku":"SKU-1","upc":"012345678905","lotNumber":null,"expiryDate":null,"quantity":10,"poNumber":"PO-1"}`,
+		}, "PO: PO-1"},
+		{"pick", labelbus.LabelCatalog{
+			Code: "PK-1", Type: labelbus.TypePick,
+			PayloadJSON: `{"orderNumber":"SO-1","customerName":"Acme","productName":"Gadget","sku":"SKU-2","upc":"098765432105","lotNumber":null,"serialNumbers":[],"quantity":5,"locationCode":"STG-A02"}`,
+		}, "Order: SO-1"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := labelbus.Render(tc.lc)
+			if err != nil {
+				t.Fatalf("Render: %v", err)
+			}
+			if !strings.Contains(string(out), tc.want) {
+				t.Fatalf("expected %q in output, got: %s", tc.want, out)
+			}
+		})
+	}
+}
+
+func Test_Render_UnknownType(t *testing.T) {
+	_, err := labelbus.Render(labelbus.LabelCatalog{Code: "X", Type: "nonsense"})
+	if err == nil {
+		t.Fatal("expected error for unknown type, got nil")
+	}
+}
+
+func Test_Render_BadPayload(t *testing.T) {
+	_, err := labelbus.Render(labelbus.LabelCatalog{
+		Code: "RX", Type: labelbus.TypeReceiving, PayloadJSON: `{not json`,
+	})
+	if err == nil {
+		t.Fatal("expected unmarshal error, got nil")
 	}
 }

--- a/business/domain/labels/labelbus/model.go
+++ b/business/domain/labels/labelbus/model.go
@@ -1,0 +1,44 @@
+package labelbus
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Label types — matches catalog spec §3.3.
+const (
+	TypeLocation  = "location"
+	TypeTote      = "tote"
+	TypeLot       = "lot"
+	TypeSerial    = "serial"
+	TypeProduct   = "product"
+	TypeReceiving = "receiving"
+	TypePick      = "pick"
+)
+
+// LabelCatalog represents one stable printable label definition.
+type LabelCatalog struct {
+	ID          uuid.UUID
+	Code        string
+	Type        string
+	EntityRef   string
+	PayloadJSON string
+	CreatedDate time.Time
+}
+
+// NewLabelCatalog is what callers provide to create a new entry.
+type NewLabelCatalog struct {
+	Code        string
+	Type        string
+	EntityRef   string
+	PayloadJSON string
+}
+
+// UpdateLabelCatalog carries optional patch fields.
+type UpdateLabelCatalog struct {
+	Code        *string
+	Type        *string
+	EntityRef   *string
+	PayloadJSON *string
+}

--- a/business/domain/labels/labelbus/order.go
+++ b/business/domain/labels/labelbus/order.go
@@ -1,0 +1,12 @@
+package labelbus
+
+import "github.com/timmaaaz/ichor/business/sdk/order"
+
+const (
+	OrderByID          = "label_id"
+	OrderByCode        = "code"
+	OrderByType        = "type"
+	OrderByCreatedDate = "created_date"
+)
+
+var DefaultOrderBy = order.NewBy(OrderByCode, order.ASC)

--- a/business/domain/labels/labelbus/render.go
+++ b/business/domain/labels/labelbus/render.go
@@ -1,8 +1,35 @@
 package labelbus
 
-import "errors"
+import (
+	"encoding/json"
+	"fmt"
 
-// Render is implemented in Task 0b.5.
+	"github.com/timmaaaz/ichor/business/domain/labels/labelbus/zpl"
+)
+
+// Render dispatches to the appropriate ZPL template based on label Type.
+// For location/tote, uses only lc.Code. For receiving/pick, unmarshals
+// lc.PayloadJSON into the typed data struct (JSON tags match TS field
+// names in zpl/types.go so frontend payloads pass through unchanged).
 func Render(lc LabelCatalog) ([]byte, error) {
-	return nil, errors.New("render: not yet implemented")
+	switch lc.Type {
+	case TypeLocation:
+		return []byte(zpl.Location(zpl.LocationData{Code: lc.Code})), nil
+	case TypeTote:
+		return []byte(zpl.Tote(zpl.ToteData{Code: lc.Code})), nil
+	case TypeReceiving:
+		var d zpl.ReceivingData
+		if err := json.Unmarshal([]byte(lc.PayloadJSON), &d); err != nil {
+			return nil, fmt.Errorf("unmarshal receiving: %w", err)
+		}
+		return []byte(zpl.Receiving(d)), nil
+	case TypePick:
+		var d zpl.PickData
+		if err := json.Unmarshal([]byte(lc.PayloadJSON), &d); err != nil {
+			return nil, fmt.Errorf("unmarshal pick: %w", err)
+		}
+		return []byte(zpl.Pick(d)), nil
+	default:
+		return nil, fmt.Errorf("unknown label type: %q", lc.Type)
+	}
 }

--- a/business/domain/labels/labelbus/render.go
+++ b/business/domain/labels/labelbus/render.go
@@ -1,0 +1,8 @@
+package labelbus
+
+import "errors"
+
+// Render is implemented in Task 0b.5.
+func Render(lc LabelCatalog) ([]byte, error) {
+	return nil, errors.New("render: not yet implemented")
+}

--- a/business/domain/labels/labelbus/render.go
+++ b/business/domain/labels/labelbus/render.go
@@ -11,22 +11,43 @@ import (
 // For location/tote, uses only lc.Code. For receiving/pick, unmarshals
 // lc.PayloadJSON into the typed data struct (JSON tags match TS field
 // names in zpl/types.go so frontend payloads pass through unchanged).
+//
+// All user-supplied string fields are passed through zpl.Sanitize to
+// strip ZPL command-prefix characters (^ and ~) before rendering.
+// Without this, a payload containing `^FS^XZ^XA...` could terminate
+// a data field and inject arbitrary commands into the print stream.
 func Render(lc LabelCatalog) ([]byte, error) {
 	switch lc.Type {
 	case TypeLocation:
-		return []byte(zpl.Location(zpl.LocationData{Code: lc.Code})), nil
+		return []byte(zpl.Location(zpl.LocationData{Code: zpl.Sanitize(lc.Code)})), nil
 	case TypeTote:
-		return []byte(zpl.Tote(zpl.ToteData{Code: lc.Code})), nil
+		return []byte(zpl.Tote(zpl.ToteData{Code: zpl.Sanitize(lc.Code)})), nil
 	case TypeReceiving:
 		var d zpl.ReceivingData
 		if err := json.Unmarshal([]byte(lc.PayloadJSON), &d); err != nil {
 			return nil, fmt.Errorf("unmarshal receiving: %w", err)
 		}
+		d.ProductName = zpl.Sanitize(d.ProductName)
+		d.SKU = zpl.Sanitize(d.SKU)
+		d.UPC = zpl.Sanitize(d.UPC)
+		d.LotNumber = zpl.SanitizePtr(d.LotNumber)
+		d.ExpiryDate = zpl.SanitizePtr(d.ExpiryDate)
+		d.PONumber = zpl.Sanitize(d.PONumber)
 		return []byte(zpl.Receiving(d)), nil
 	case TypePick:
 		var d zpl.PickData
 		if err := json.Unmarshal([]byte(lc.PayloadJSON), &d); err != nil {
 			return nil, fmt.Errorf("unmarshal pick: %w", err)
+		}
+		d.OrderNumber = zpl.Sanitize(d.OrderNumber)
+		d.CustomerName = zpl.Sanitize(d.CustomerName)
+		d.ProductName = zpl.Sanitize(d.ProductName)
+		d.SKU = zpl.Sanitize(d.SKU)
+		d.UPC = zpl.Sanitize(d.UPC)
+		d.LotNumber = zpl.SanitizePtr(d.LotNumber)
+		d.LocationCode = zpl.Sanitize(d.LocationCode)
+		for i := range d.SerialNumbers {
+			d.SerialNumbers[i] = zpl.Sanitize(d.SerialNumbers[i])
 		}
 		return []byte(zpl.Pick(d)), nil
 	default:

--- a/business/domain/labels/labelbus/stores/labeldb/filter.go
+++ b/business/domain/labels/labelbus/stores/labeldb/filter.go
@@ -1,0 +1,32 @@
+package labeldb
+
+import (
+	"bytes"
+	"strings"
+
+	"github.com/timmaaaz/ichor/business/domain/labels/labelbus"
+)
+
+func applyFilter(filter labelbus.QueryFilter, data map[string]interface{}, buf *bytes.Buffer) {
+	var wc []string
+
+	if filter.ID != nil {
+		data["id"] = *filter.ID
+		wc = append(wc, "id = :id")
+	}
+
+	if filter.Code != nil {
+		data["code"] = *filter.Code
+		wc = append(wc, "code = :code")
+	}
+
+	if filter.Type != nil {
+		data["type"] = *filter.Type
+		wc = append(wc, "type = :type")
+	}
+
+	if len(wc) > 0 {
+		buf.WriteString(" WHERE ")
+		buf.WriteString(strings.Join(wc, " AND "))
+	}
+}

--- a/business/domain/labels/labelbus/stores/labeldb/labeldb.go
+++ b/business/domain/labels/labelbus/stores/labeldb/labeldb.go
@@ -1,0 +1,210 @@
+// Package labeldb provides the Postgres implementation of labelbus.Storer.
+package labeldb
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+	"github.com/timmaaaz/ichor/business/domain/labels/labelbus"
+	"github.com/timmaaaz/ichor/business/sdk/order"
+	"github.com/timmaaaz/ichor/business/sdk/page"
+	"github.com/timmaaaz/ichor/business/sdk/sqldb"
+	"github.com/timmaaaz/ichor/foundation/logger"
+)
+
+// Store manages the set of APIs for label_catalog database access.
+type Store struct {
+	log *logger.Logger
+	db  sqlx.ExtContext
+}
+
+// NewStore constructs the api for data access.
+func NewStore(log *logger.Logger, db *sqlx.DB) *Store {
+	return &Store{
+		log: log,
+		db:  db,
+	}
+}
+
+// NewWithTx constructs a new Store value replacing the sqlx DB value with one
+// currently inside a transaction.
+func (s *Store) NewWithTx(tx sqldb.CommitRollbacker) (labelbus.Storer, error) {
+	ec, err := sqldb.GetExtContext(tx)
+	if err != nil {
+		return nil, err
+	}
+
+	store := Store{
+		log: s.log,
+		db:  ec,
+	}
+
+	return &store, nil
+}
+
+// Create inserts a new label catalog row.
+func (s *Store) Create(ctx context.Context, lc labelbus.LabelCatalog) error {
+	const q = `
+	INSERT INTO inventory.label_catalog (
+		id, code, type, entity_ref, payload_json, created_date
+	) VALUES (
+		:id, :code, :type, :entity_ref, :payload_json, :created_date
+	)`
+
+	if err := sqldb.NamedExecContext(ctx, s.log, s.db, q, toDBLabelCatalog(lc)); err != nil {
+		if errors.Is(err, sqldb.ErrDBDuplicatedEntry) {
+			return fmt.Errorf("namedexeccontext: %w", labelbus.ErrUniqueCode)
+		}
+		return fmt.Errorf("namedexeccontext: %w", err)
+	}
+	return nil
+}
+
+// Update replaces an existing label catalog row.
+func (s *Store) Update(ctx context.Context, lc labelbus.LabelCatalog) error {
+	const q = `
+	UPDATE
+		inventory.label_catalog
+	SET
+		code = :code,
+		type = :type,
+		entity_ref = :entity_ref,
+		payload_json = :payload_json
+	WHERE
+		id = :id`
+
+	if err := sqldb.NamedExecContext(ctx, s.log, s.db, q, toDBLabelCatalog(lc)); err != nil {
+		if errors.Is(err, sqldb.ErrDBDuplicatedEntry) {
+			return fmt.Errorf("namedexeccontext: %w", labelbus.ErrUniqueCode)
+		}
+		return fmt.Errorf("namedexeccontext: %w", err)
+	}
+	return nil
+}
+
+// Delete removes a label catalog row.
+func (s *Store) Delete(ctx context.Context, lc labelbus.LabelCatalog) error {
+	const q = `
+	DELETE FROM
+		inventory.label_catalog
+	WHERE
+		id = :id`
+
+	if err := sqldb.NamedExecContext(ctx, s.log, s.db, q, toDBLabelCatalog(lc)); err != nil {
+		return fmt.Errorf("namedexeccontext: %w", err)
+	}
+	return nil
+}
+
+// Query retrieves a page of label catalog rows.
+func (s *Store) Query(ctx context.Context, filter labelbus.QueryFilter, orderBy order.By, pg page.Page) ([]labelbus.LabelCatalog, error) {
+	data := map[string]any{
+		"offset":        (pg.Number() - 1) * pg.RowsPerPage(),
+		"rows_per_page": pg.RowsPerPage(),
+	}
+
+	const q = `
+	SELECT
+		id, code, type, entity_ref, payload_json, created_date
+	FROM
+		inventory.label_catalog`
+
+	buf := bytes.NewBufferString(q)
+	applyFilter(filter, data, buf)
+
+	orderByClause, err := orderByClause(orderBy)
+	if err != nil {
+		return nil, err
+	}
+
+	buf.WriteString(orderByClause)
+	buf.WriteString(" OFFSET :offset ROWS FETCH NEXT :rows_per_page ROWS ONLY")
+
+	var rows []labelCatalog
+	if err := sqldb.NamedQuerySlice(ctx, s.log, s.db, buf.String(), data, &rows); err != nil {
+		return nil, fmt.Errorf("namedqueryslice: %w", err)
+	}
+
+	return toBusLabelCatalogs(rows), nil
+}
+
+// Count returns the number of label catalog rows matching the filter.
+func (s *Store) Count(ctx context.Context, filter labelbus.QueryFilter) (int, error) {
+	data := map[string]any{}
+
+	const q = `
+	SELECT
+		COUNT(1) AS count
+	FROM
+		inventory.label_catalog`
+
+	buf := bytes.NewBufferString(q)
+	applyFilter(filter, data, buf)
+
+	var count struct {
+		Count int `db:"count"`
+	}
+	if err := sqldb.NamedQueryStruct(ctx, s.log, s.db, buf.String(), data, &count); err != nil {
+		return 0, fmt.Errorf("namedquerystruct: %w", err)
+	}
+
+	return count.Count, nil
+}
+
+// QueryByID retrieves a single label catalog row by ID.
+func (s *Store) QueryByID(ctx context.Context, id uuid.UUID) (labelbus.LabelCatalog, error) {
+	data := struct {
+		ID string `db:"id"`
+	}{
+		ID: id.String(),
+	}
+
+	const q = `
+	SELECT
+		id, code, type, entity_ref, payload_json, created_date
+	FROM
+		inventory.label_catalog
+	WHERE
+		id = :id`
+
+	var row labelCatalog
+	if err := sqldb.NamedQueryStruct(ctx, s.log, s.db, q, data, &row); err != nil {
+		if errors.Is(err, sqldb.ErrDBNotFound) {
+			return labelbus.LabelCatalog{}, labelbus.ErrNotFound
+		}
+		return labelbus.LabelCatalog{}, fmt.Errorf("namedquerystruct: %w", err)
+	}
+
+	return toBusLabelCatalog(row), nil
+}
+
+// QueryByCode retrieves a single label catalog row by its stable code.
+func (s *Store) QueryByCode(ctx context.Context, code string) (labelbus.LabelCatalog, error) {
+	data := struct {
+		Code string `db:"code"`
+	}{
+		Code: code,
+	}
+
+	const q = `
+	SELECT
+		id, code, type, entity_ref, payload_json, created_date
+	FROM
+		inventory.label_catalog
+	WHERE
+		code = :code`
+
+	var row labelCatalog
+	if err := sqldb.NamedQueryStruct(ctx, s.log, s.db, q, data, &row); err != nil {
+		if errors.Is(err, sqldb.ErrDBNotFound) {
+			return labelbus.LabelCatalog{}, labelbus.ErrNotFound
+		}
+		return labelbus.LabelCatalog{}, fmt.Errorf("namedquerystruct: %w", err)
+	}
+
+	return toBusLabelCatalog(row), nil
+}

--- a/business/domain/labels/labelbus/stores/labeldb/labeldb_test.go
+++ b/business/domain/labels/labelbus/stores/labeldb/labeldb_test.go
@@ -1,0 +1,102 @@
+package labeldb_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/timmaaaz/ichor/business/domain/labels/labelbus"
+	"github.com/timmaaaz/ichor/business/domain/labels/labelbus/stores/labeldb"
+	"github.com/timmaaaz/ichor/business/sdk/dbtest"
+)
+
+func Test_LabelCatalog_CreateQueryByCode(t *testing.T) {
+	t.Parallel()
+
+	db := dbtest.NewDatabase(t, "Test_LabelCatalog_CreateQueryByCode")
+
+	store := labeldb.NewStore(db.Log, db.DB)
+
+	ctx := context.Background()
+
+	lc := labelbus.LabelCatalog{
+		ID:          uuid.New(),
+		Code:        "LOC-A-01",
+		Type:        labelbus.TypeLocation,
+		EntityRef:   "warehouse-a/aisle-01",
+		PayloadJSON: `{"zone":"A"}`,
+		CreatedDate: time.Now(),
+	}
+
+	if err := store.Create(ctx, lc); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	got, err := store.QueryByCode(ctx, lc.Code)
+	if err != nil {
+		t.Fatalf("querybycode: %v", err)
+	}
+
+	if got.ID != lc.ID {
+		t.Errorf("ID: got %s, want %s", got.ID, lc.ID)
+	}
+	if got.Code != lc.Code {
+		t.Errorf("Code: got %q, want %q", got.Code, lc.Code)
+	}
+	if got.Type != lc.Type {
+		t.Errorf("Type: got %q, want %q", got.Type, lc.Type)
+	}
+	if got.EntityRef != lc.EntityRef {
+		t.Errorf("EntityRef: got %q, want %q", got.EntityRef, lc.EntityRef)
+	}
+	if got.PayloadJSON != lc.PayloadJSON {
+		t.Errorf("PayloadJSON: got %q, want %q", got.PayloadJSON, lc.PayloadJSON)
+	}
+}
+
+func Test_LabelCatalog_DuplicateCode(t *testing.T) {
+	t.Parallel()
+
+	db := dbtest.NewDatabase(t, "Test_LabelCatalog_DuplicateCode")
+
+	store := labeldb.NewStore(db.Log, db.DB)
+	ctx := context.Background()
+
+	lc := labelbus.LabelCatalog{
+		ID:          uuid.New(),
+		Code:        "DUPE-01",
+		Type:        labelbus.TypeTote,
+		PayloadJSON: `{}`,
+		CreatedDate: time.Now(),
+	}
+	if err := store.Create(ctx, lc); err != nil {
+		t.Fatalf("create first: %v", err)
+	}
+
+	lc2 := lc
+	lc2.ID = uuid.New()
+	err := store.Create(ctx, lc2)
+	if err == nil {
+		t.Fatalf("expected duplicate-code error, got nil")
+	}
+	// Business sentinel should be wrapped.
+	if !isUniqueCode(err) {
+		t.Fatalf("expected ErrUniqueCode in chain, got %v", err)
+	}
+}
+
+func isUniqueCode(err error) bool {
+	for e := err; e != nil; {
+		if e == labelbus.ErrUniqueCode {
+			return true
+		}
+		type unwrapper interface{ Unwrap() error }
+		u, ok := e.(unwrapper)
+		if !ok {
+			return false
+		}
+		e = u.Unwrap()
+	}
+	return false
+}

--- a/business/domain/labels/labelbus/stores/labeldb/model.go
+++ b/business/domain/labels/labelbus/stores/labeldb/model.go
@@ -1,0 +1,58 @@
+package labeldb
+
+import (
+	"database/sql"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/timmaaaz/ichor/business/domain/labels/labelbus"
+)
+
+type labelCatalog struct {
+	ID          uuid.UUID      `db:"id"`
+	Code        string         `db:"code"`
+	Type        string         `db:"type"`
+	EntityRef   sql.NullString `db:"entity_ref"`
+	PayloadJSON string         `db:"payload_json"`
+	CreatedDate time.Time      `db:"created_date"`
+}
+
+func toDBLabelCatalog(bus labelbus.LabelCatalog) labelCatalog {
+	var entityRef sql.NullString
+	if bus.EntityRef != "" {
+		entityRef = sql.NullString{String: bus.EntityRef, Valid: true}
+	}
+
+	return labelCatalog{
+		ID:          bus.ID,
+		Code:        bus.Code,
+		Type:        bus.Type,
+		EntityRef:   entityRef,
+		PayloadJSON: bus.PayloadJSON,
+		CreatedDate: bus.CreatedDate.UTC(),
+	}
+}
+
+func toBusLabelCatalog(db labelCatalog) labelbus.LabelCatalog {
+	var entityRef string
+	if db.EntityRef.Valid {
+		entityRef = db.EntityRef.String
+	}
+
+	return labelbus.LabelCatalog{
+		ID:          db.ID,
+		Code:        db.Code,
+		Type:        db.Type,
+		EntityRef:   entityRef,
+		PayloadJSON: db.PayloadJSON,
+		CreatedDate: db.CreatedDate.In(time.Local),
+	}
+}
+
+func toBusLabelCatalogs(dbs []labelCatalog) []labelbus.LabelCatalog {
+	out := make([]labelbus.LabelCatalog, len(dbs))
+	for i, d := range dbs {
+		out[i] = toBusLabelCatalog(d)
+	}
+	return out
+}

--- a/business/domain/labels/labelbus/stores/labeldb/order.go
+++ b/business/domain/labels/labelbus/stores/labeldb/order.go
@@ -1,0 +1,24 @@
+package labeldb
+
+import (
+	"fmt"
+
+	"github.com/timmaaaz/ichor/business/domain/labels/labelbus"
+	"github.com/timmaaaz/ichor/business/sdk/order"
+)
+
+var orderByFields = map[string]string{
+	labelbus.OrderByID:          "id",
+	labelbus.OrderByCode:        "code",
+	labelbus.OrderByType:        "type",
+	labelbus.OrderByCreatedDate: "created_date",
+}
+
+func orderByClause(orderBy order.By) (string, error) {
+	by, exists := orderByFields[orderBy.Field]
+	if !exists {
+		return "", fmt.Errorf("field %q does not exist", orderBy.Field)
+	}
+
+	return " ORDER BY " + by + " " + orderBy.Direction, nil
+}

--- a/business/domain/labels/labelbus/tcpprint/tcpprint.go
+++ b/business/domain/labels/labelbus/tcpprint/tcpprint.go
@@ -25,7 +25,16 @@ func New(host, port string, timeout time.Duration) *Printer {
 // SendZPL opens a TCP connection, writes the ZPL bytes, and closes.
 // A single retry is attempted on dial failure after a 250ms backoff,
 // since printers occasionally refuse the first connection after idle.
+//
+// An empty host is a no-op: this honours the mux.Config contract that
+// "Empty PrinterIP disables actual network dispatch". Without the
+// guard, net.JoinHostPort("", port) yields ":9100" and the printer
+// dials localhost at request time, which is both unsafe and
+// surprising in environments that intentionally leave PrinterIP unset.
 func (p *Printer) SendZPL(ctx context.Context, zpl []byte) error {
+	if p.host == "" {
+		return nil
+	}
 	d := net.Dialer{Timeout: p.timeout}
 	addr := net.JoinHostPort(p.host, p.port)
 

--- a/business/domain/labels/labelbus/tcpprint/tcpprint.go
+++ b/business/domain/labels/labelbus/tcpprint/tcpprint.go
@@ -40,7 +40,11 @@ func (p *Printer) SendZPL(ctx context.Context, zpl []byte) error {
 
 	conn, err := d.DialContext(ctx, "tcp", addr)
 	if err != nil {
-		time.Sleep(250 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(250 * time.Millisecond):
+		}
 		conn, err = d.DialContext(ctx, "tcp", addr)
 		if err != nil {
 			return fmt.Errorf("dial %s: %w", addr, err)
@@ -54,8 +58,12 @@ func (p *Printer) SendZPL(ctx context.Context, zpl []byte) error {
 	}
 	_ = conn.SetWriteDeadline(deadline)
 
-	if _, err := conn.Write(zpl); err != nil {
+	n, err := conn.Write(zpl)
+	if err != nil {
 		return fmt.Errorf("write zpl: %w", err)
+	}
+	if n != len(zpl) {
+		return fmt.Errorf("write zpl: short write: wrote %d of %d bytes", n, len(zpl))
 	}
 	return nil
 }

--- a/business/domain/labels/labelbus/tcpprint/tcpprint.go
+++ b/business/domain/labels/labelbus/tcpprint/tcpprint.go
@@ -1,0 +1,52 @@
+// Package tcpprint writes ZPL bytes directly to a Zebra-compatible TCP
+// printer on port 9100 (PDL-datastream). One-shot connection per print;
+// no pooling (printers often reset the connection after each job).
+package tcpprint
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+)
+
+// Printer sends ZPL bytes to a network-attached thermal printer.
+type Printer struct {
+	host    string
+	port    string
+	timeout time.Duration
+}
+
+// New constructs a Printer. `timeout` caps both dial and write durations.
+func New(host, port string, timeout time.Duration) *Printer {
+	return &Printer{host: host, port: port, timeout: timeout}
+}
+
+// SendZPL opens a TCP connection, writes the ZPL bytes, and closes.
+// A single retry is attempted on dial failure after a 250ms backoff,
+// since printers occasionally refuse the first connection after idle.
+func (p *Printer) SendZPL(ctx context.Context, zpl []byte) error {
+	d := net.Dialer{Timeout: p.timeout}
+	addr := net.JoinHostPort(p.host, p.port)
+
+	conn, err := d.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		time.Sleep(250 * time.Millisecond)
+		conn, err = d.DialContext(ctx, "tcp", addr)
+		if err != nil {
+			return fmt.Errorf("dial %s: %w", addr, err)
+		}
+	}
+	defer conn.Close()
+
+	deadline := time.Now().Add(p.timeout)
+	if dl, ok := ctx.Deadline(); ok && dl.Before(deadline) {
+		deadline = dl
+	}
+	_ = conn.SetWriteDeadline(deadline)
+
+	if _, err := conn.Write(zpl); err != nil {
+		return fmt.Errorf("write zpl: %w", err)
+	}
+	return nil
+}

--- a/business/domain/labels/labelbus/tcpprint/tcpprint_nohost_test.go
+++ b/business/domain/labels/labelbus/tcpprint/tcpprint_nohost_test.go
@@ -1,0 +1,20 @@
+package tcpprint_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/timmaaaz/ichor/business/domain/labels/labelbus/tcpprint"
+)
+
+// Test_TCPPrinter_EmptyHostNoop verifies that an empty host short-
+// circuits SendZPL with nil — honouring mux.Config's "Empty PrinterIP
+// disables actual network dispatch" contract. Without the guard,
+// net.JoinHostPort("", "9100") dials localhost:9100 at request time.
+func Test_TCPPrinter_EmptyHostNoop(t *testing.T) {
+	p := tcpprint.New("", "9100", 500*time.Millisecond)
+	if err := p.SendZPL(context.Background(), []byte("^XA^XZ")); err != nil {
+		t.Fatalf("SendZPL with empty host should be no-op, got: %v", err)
+	}
+}

--- a/business/domain/labels/labelbus/tcpprint/tcpprint_test.go
+++ b/business/domain/labels/labelbus/tcpprint/tcpprint_test.go
@@ -1,0 +1,56 @@
+package tcpprint_test
+
+import (
+	"context"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/timmaaaz/ichor/business/domain/labels/labelbus/tcpprint"
+)
+
+func Test_TCPPrinter_SendZPL(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	received := make(chan string, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		data, _ := io.ReadAll(conn)
+		received <- string(data)
+	}()
+
+	host, port, _ := net.SplitHostPort(ln.Addr().String())
+	p := tcpprint.New(host, port, 2*time.Second)
+
+	payload := "^XA\n^FDHELLO^FS\n^XZ\n"
+	if err := p.SendZPL(context.Background(), []byte(payload)); err != nil {
+		t.Fatalf("SendZPL: %v", err)
+	}
+
+	select {
+	case got := <-received:
+		if got != payload {
+			t.Fatalf("bytes mismatch: want %q got %q", payload, got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for bytes")
+	}
+}
+
+func Test_TCPPrinter_DialFailure(t *testing.T) {
+	// 127.0.0.1:1 is virtually guaranteed to refuse; timeout is hard cap.
+	p := tcpprint.New("127.0.0.1", "1", 500*time.Millisecond)
+	err := p.SendZPL(context.Background(), []byte("^XA^XZ"))
+	if err == nil {
+		t.Fatal("expected dial error, got nil")
+	}
+}

--- a/business/domain/labels/labelbus/testutil.go
+++ b/business/domain/labels/labelbus/testutil.go
@@ -1,0 +1,3 @@
+package labelbus
+
+// Additional test fixtures will be added when integration tests need them.

--- a/business/domain/labels/labelbus/testutil.go
+++ b/business/domain/labels/labelbus/testutil.go
@@ -1,3 +1,41 @@
 package labelbus
 
-// Additional test fixtures will be added when integration tests need them.
+import (
+	"context"
+	"fmt"
+	"sort"
+)
+
+// TestNewLabels generates n NewLabelCatalog values with deterministic codes.
+func TestNewLabels(n int) []NewLabelCatalog {
+	labels := make([]NewLabelCatalog, n)
+	for i := range n {
+		labels[i] = NewLabelCatalog{
+			Code:      fmt.Sprintf("TEST-%04d", i+1),
+			Type:      TypeLocation,
+			EntityRef: "",
+		}
+	}
+	return labels
+}
+
+// TestSeedLabels creates n labels in the database for testing and returns
+// them sorted by ID for stable comparison.
+func TestSeedLabels(ctx context.Context, n int, api *Business) ([]LabelCatalog, error) {
+	newLabels := TestNewLabels(n)
+
+	labels := make([]LabelCatalog, len(newLabels))
+	for i, nl := range newLabels {
+		lc, err := api.Create(ctx, nl)
+		if err != nil {
+			return nil, fmt.Errorf("seeding label %d: %w", i, err)
+		}
+		labels[i] = lc
+	}
+
+	sort.Slice(labels, func(i, j int) bool {
+		return labels[i].ID.String() < labels[j].ID.String()
+	})
+
+	return labels, nil
+}

--- a/business/domain/labels/labelbus/zpl/location.go
+++ b/business/domain/labels/labelbus/zpl/location.go
@@ -1,0 +1,18 @@
+package zpl
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Location renders a 2"×1" @ 203 DPI ZPL location label:
+// human-readable code + Code128 barcode of the same code.
+// Matches the Phase 0 smoke pattern (NOTES.md 2026-04-14).
+func Location(d LocationData) string {
+	var b strings.Builder
+	b.WriteString("^XA\n")
+	b.WriteString(fmt.Sprintf("^FO50,50^A0N,40,40^FD%s^FS\n", d.Code))
+	b.WriteString(fmt.Sprintf("^FO50,100^BY2^BCN,80,Y,N,N^FD%s^FS\n", d.Code))
+	b.WriteString("^XZ\n")
+	return b.String()
+}

--- a/business/domain/labels/labelbus/zpl/pick.go
+++ b/business/domain/labels/labelbus/zpl/pick.go
@@ -1,0 +1,61 @@
+package zpl
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Pick renders a 4"×2" @ 203 DPI ZPL pick label.
+// Byte-equivalent port of src/utils/zpl/pickLabel.ts.
+func Pick(d PickData) string {
+	name := d.ProductName
+	if len(name) > 30 {
+		name = name[:27] + "..."
+	}
+
+	customer := d.CustomerName
+	if len(customer) > 25 {
+		customer = customer[:22] + "..."
+	}
+
+	y := 20
+	lines := []string{
+		"^XA",
+		fmt.Sprintf("^FO30,%d^A0N,28,28^FDOrder: %s^FS", y, d.OrderNumber),
+	}
+
+	y += 32
+	lines = append(lines, fmt.Sprintf("^FO30,%d^A0N,22,22^FD%s^FS", y, customer))
+
+	y += 30
+	lines = append(lines, fmt.Sprintf("^FO30,%d^A0N,28,28^FD%s^FS", y, name))
+
+	y += 35
+	lines = append(lines, fmt.Sprintf("^FO30,%d^A0N,22,22^FDSKU: %s^FS", y, d.SKU))
+
+	y += 32
+	lines = append(lines, fmt.Sprintf("^FO30,%d^BCN,50,Y,N,N^FD%s^FS", y, d.UPC))
+
+	y += 80
+	if d.LotNumber != nil {
+		lines = append(lines, fmt.Sprintf("^FO30,%d^A0N,22,22^FDLOT: %s  QTY: %d^FS", y, *d.LotNumber, d.Quantity))
+	} else {
+		lines = append(lines, fmt.Sprintf("^FO30,%d^A0N,22,22^FDQTY: %d^FS", y, d.Quantity))
+	}
+
+	y += 30
+	if len(d.SerialNumbers) > 0 {
+		serials := strings.Join(d.SerialNumbers, ", ")
+		truncated := serials
+		if len(truncated) > 50 {
+			truncated = truncated[:47] + "..."
+		}
+		lines = append(lines, fmt.Sprintf("^FO30,%d^A0N,20,20^FDS/N: %s^FS", y, truncated))
+		y += 28
+	}
+
+	lines = append(lines, fmt.Sprintf("^FO30,%d^A0N,22,22^FDFrom: %s^FS", y, d.LocationCode))
+
+	lines = append(lines, "^XZ")
+	return strings.Join(lines, "\n")
+}

--- a/business/domain/labels/labelbus/zpl/receiving.go
+++ b/business/domain/labels/labelbus/zpl/receiving.go
@@ -1,0 +1,44 @@
+package zpl
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Receiving renders a 4"×2" @ 203 DPI ZPL receiving label.
+// Byte-equivalent port of src/utils/zpl/receivingLabel.ts.
+func Receiving(d ReceivingData) string {
+	name := d.ProductName
+	if len(name) > 30 {
+		name = name[:27] + "..."
+	}
+
+	y := 30
+	lines := []string{
+		"^XA",
+		fmt.Sprintf("^FO30,%d^A0N,36,36^FD%s^FS", y, name),
+	}
+
+	y += 45
+	lines = append(lines, fmt.Sprintf("^FO30,%d^A0N,24,24^FDSKU: %s^FS", y, d.SKU))
+
+	y += 40
+	lines = append(lines, fmt.Sprintf("^FO30,%d^BCN,60,Y,N,N^FD%s^FS", y, d.UPC))
+
+	y += 95
+	if d.LotNumber != nil {
+		var lotLine string
+		if d.ExpiryDate != nil {
+			lotLine = fmt.Sprintf("LOT: %s  EXP: %s", *d.LotNumber, *d.ExpiryDate)
+		} else {
+			lotLine = fmt.Sprintf("LOT: %s", *d.LotNumber)
+		}
+		lines = append(lines, fmt.Sprintf("^FO30,%d^A0N,24,24^FD%s^FS", y, lotLine))
+		y += 35
+	}
+
+	lines = append(lines, fmt.Sprintf("^FO30,%d^A0N,24,24^FDQTY: %d  PO: %s^FS", y, d.Quantity, d.PONumber))
+
+	lines = append(lines, "^XZ")
+	return strings.Join(lines, "\n")
+}

--- a/business/domain/labels/labelbus/zpl/sanitize.go
+++ b/business/domain/labels/labelbus/zpl/sanitize.go
@@ -1,0 +1,38 @@
+package zpl
+
+import "strings"
+
+// Sanitize strips ZPL command-prefix characters from user-supplied
+// strings before they are interpolated into ^FD data fields.
+//
+// ZPL's default format-command prefix is `^` (e.g. ^XA / ^FD / ^FS)
+// and default control-command prefix is `~` (e.g. ~JS / ~HI). Inside
+// a ^FD field an attacker-controlled `^FS` would terminate the field
+// and allow arbitrary subsequent commands (^XZ^XA...). Stripping
+// both prefixes neutralizes that path. The `,` parameter delimiter
+// is intentionally preserved: it has no command effect inside ^FD
+// and appears legitimately in names like "Acme, Inc.".
+func Sanitize(s string) string {
+	if !strings.ContainsAny(s, "^~") {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		if r == '^' || r == '~' {
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
+// SanitizePtr returns nil when p is nil, otherwise a pointer to the
+// sanitized copy of *p.
+func SanitizePtr(p *string) *string {
+	if p == nil {
+		return nil
+	}
+	s := Sanitize(*p)
+	return &s
+}

--- a/business/domain/labels/labelbus/zpl/sanitize_test.go
+++ b/business/domain/labels/labelbus/zpl/sanitize_test.go
@@ -1,0 +1,48 @@
+package zpl_test
+
+import (
+	"testing"
+
+	"github.com/timmaaaz/ichor/business/domain/labels/labelbus/zpl"
+)
+
+func Test_Sanitize(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain text passes through", "Widget A", "Widget A"},
+		{"comma preserved", "Acme, Inc.", "Acme, Inc."},
+		{"caret stripped", "Evil^FS^XZ^XA^FD", "EvilFSXZXAFD"},
+		{"tilde stripped", "~JSNormal", "JSNormal"},
+		{"both stripped", "^FS~HI", "FSHI"},
+		{"unicode preserved", "Café Öl ✓", "Café Öl ✓"},
+		{"empty", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := zpl.Sanitize(tc.in)
+			if got != tc.want {
+				t.Fatalf("Sanitize(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func Test_SanitizePtr_Nil(t *testing.T) {
+	if got := zpl.SanitizePtr(nil); got != nil {
+		t.Fatalf("SanitizePtr(nil) = %v, want nil", got)
+	}
+}
+
+func Test_SanitizePtr_Value(t *testing.T) {
+	in := "LOT-^FS"
+	got := zpl.SanitizePtr(&in)
+	if got == nil {
+		t.Fatal("SanitizePtr returned nil for non-nil input")
+	}
+	if *got != "LOT-FS" {
+		t.Fatalf("SanitizePtr: want %q, got %q", "LOT-FS", *got)
+	}
+}

--- a/business/domain/labels/labelbus/zpl/tote.go
+++ b/business/domain/labels/labelbus/zpl/tote.go
@@ -1,0 +1,19 @@
+package zpl
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Tote renders a 2"×1" @ 203 DPI ZPL tote label.
+// Shares layout with Location at Phase 0b; diverges in Phase 1+ when
+// totes gain lot-expiry/icon fields. Kept as a separate function so
+// call sites read intention rather than implementation.
+func Tote(d ToteData) string {
+	var b strings.Builder
+	b.WriteString("^XA\n")
+	b.WriteString(fmt.Sprintf("^FO50,50^A0N,40,40^FD%s^FS\n", d.Code))
+	b.WriteString(fmt.Sprintf("^FO50,100^BY2^BCN,80,Y,N,N^FD%s^FS\n", d.Code))
+	b.WriteString("^XZ\n")
+	return b.String()
+}

--- a/business/domain/labels/labelbus/zpl/types.go
+++ b/business/domain/labels/labelbus/zpl/types.go
@@ -1,0 +1,39 @@
+// Package zpl contains ZPL template functions for printable labels.
+// Templates are byte-equivalent ports of src/utils/zpl/*.ts (deleted in 0b.14).
+// JSON tags match the TS camelCase field names so Render can unmarshal
+// payloads sent from the frontend directly.
+package zpl
+
+// ReceivingData mirrors ReceivingLabelData from src/utils/zpl/types.ts.
+type ReceivingData struct {
+	ProductName string  `json:"productName"`
+	SKU         string  `json:"sku"`
+	UPC         string  `json:"upc"`
+	LotNumber   *string `json:"lotNumber"`
+	ExpiryDate  *string `json:"expiryDate"`
+	Quantity    int     `json:"quantity"`
+	PONumber    string  `json:"poNumber"`
+}
+
+// PickData mirrors PickLabelData from src/utils/zpl/types.ts.
+type PickData struct {
+	OrderNumber   string   `json:"orderNumber"`
+	CustomerName  string   `json:"customerName"`
+	ProductName   string   `json:"productName"`
+	SKU           string   `json:"sku"`
+	UPC           string   `json:"upc"`
+	LotNumber     *string  `json:"lotNumber"`
+	SerialNumbers []string `json:"serialNumbers"`
+	Quantity      int      `json:"quantity"`
+	LocationCode  string   `json:"locationCode"`
+}
+
+// LocationData is for new location labels (no TS source).
+type LocationData struct {
+	Code string `json:"code"`
+}
+
+// ToteData is for new tote labels (no TS source).
+type ToteData struct {
+	Code string `json:"code"`
+}

--- a/business/domain/labels/labelbus/zpl/zpl_test.go
+++ b/business/domain/labels/labelbus/zpl/zpl_test.go
@@ -29,3 +29,30 @@ func Test_Receiving_Snapshot(t *testing.T) {
 		t.Fatalf("receiving snapshot drift.\nwant:\n%q\ngot:\n%q\n", want, got)
 	}
 }
+
+func Test_Pick_Snapshot(t *testing.T) {
+	got := zpl.Pick(zpl.PickData{
+		OrderNumber:   "SO-7777",
+		CustomerName:  "Acme Industries LLC",
+		ProductName:   "Gadget B Mark II",
+		SKU:           "SKU-042",
+		UPC:           "098765432105",
+		LotNumber:     strPtr("LOT-99"),
+		SerialNumbers: []string{"SN-001", "SN-002", "SN-003"},
+		Quantity:      3,
+		LocationCode:  "STG-A02",
+	})
+	want := "^XA\n" +
+		"^FO30,20^A0N,28,28^FDOrder: SO-7777^FS\n" +
+		"^FO30,52^A0N,22,22^FDAcme Industries LLC^FS\n" +
+		"^FO30,82^A0N,28,28^FDGadget B Mark II^FS\n" +
+		"^FO30,117^A0N,22,22^FDSKU: SKU-042^FS\n" +
+		"^FO30,149^BCN,50,Y,N,N^FD098765432105^FS\n" +
+		"^FO30,229^A0N,22,22^FDLOT: LOT-99  QTY: 3^FS\n" +
+		"^FO30,259^A0N,20,20^FDS/N: SN-001, SN-002, SN-003^FS\n" +
+		"^FO30,287^A0N,22,22^FDFrom: STG-A02^FS\n" +
+		"^XZ"
+	if got != want {
+		t.Fatalf("pick snapshot drift.\nwant:\n%q\ngot:\n%q\n", want, got)
+	}
+}

--- a/business/domain/labels/labelbus/zpl/zpl_test.go
+++ b/business/domain/labels/labelbus/zpl/zpl_test.go
@@ -1,0 +1,31 @@
+package zpl_test
+
+import (
+	"testing"
+
+	"github.com/timmaaaz/ichor/business/domain/labels/labelbus/zpl"
+)
+
+func strPtr(s string) *string { return &s }
+
+func Test_Receiving_Snapshot(t *testing.T) {
+	got := zpl.Receiving(zpl.ReceivingData{
+		ProductName: "Widget Assembly Type A",
+		SKU:         "SKU-001",
+		UPC:         "012345678905",
+		LotNumber:   strPtr("LOT-42"),
+		ExpiryDate:  strPtr("2027-01-15"),
+		Quantity:    100,
+		PONumber:    "PO-12345",
+	})
+	want := "^XA\n" +
+		"^FO30,30^A0N,36,36^FDWidget Assembly Type A^FS\n" +
+		"^FO30,75^A0N,24,24^FDSKU: SKU-001^FS\n" +
+		"^FO30,115^BCN,60,Y,N,N^FD012345678905^FS\n" +
+		"^FO30,210^A0N,24,24^FDLOT: LOT-42  EXP: 2027-01-15^FS\n" +
+		"^FO30,245^A0N,24,24^FDQTY: 100  PO: PO-12345^FS\n" +
+		"^XZ"
+	if got != want {
+		t.Fatalf("receiving snapshot drift.\nwant:\n%q\ngot:\n%q\n", want, got)
+	}
+}

--- a/business/domain/labels/labelbus/zpl/zpl_test.go
+++ b/business/domain/labels/labelbus/zpl/zpl_test.go
@@ -56,3 +56,25 @@ func Test_Pick_Snapshot(t *testing.T) {
 		t.Fatalf("pick snapshot drift.\nwant:\n%q\ngot:\n%q\n", want, got)
 	}
 }
+
+func Test_Location_Snapshot(t *testing.T) {
+	got := zpl.Location(zpl.LocationData{Code: "STG-A02"})
+	want := "^XA\n" +
+		"^FO50,50^A0N,40,40^FDSTG-A02^FS\n" +
+		"^FO50,100^BY2^BCN,80,Y,N,N^FDSTG-A02^FS\n" +
+		"^XZ\n"
+	if got != want {
+		t.Fatalf("location snapshot drift.\nwant:\n%q\ngot:\n%q\n", want, got)
+	}
+}
+
+func Test_Tote_Snapshot(t *testing.T) {
+	got := zpl.Tote(zpl.ToteData{Code: "TOTE-007"})
+	want := "^XA\n" +
+		"^FO50,50^A0N,40,40^FDTOTE-007^FS\n" +
+		"^FO50,100^BY2^BCN,80,Y,N,N^FDTOTE-007^FS\n" +
+		"^XZ\n"
+	if got != want {
+		t.Fatalf("tote snapshot drift.\nwant:\n%q\ngot:\n%q\n", want, got)
+	}
+}

--- a/business/sdk/dbtest/dbtest.go
+++ b/business/sdk/dbtest/dbtest.go
@@ -56,6 +56,8 @@ import (
 	"github.com/timmaaaz/ichor/business/domain/inventory/inventorylocationbus/stores/inventorylocationdb"
 	"github.com/timmaaaz/ichor/business/domain/inventory/inventorytransactionbus"
 	"github.com/timmaaaz/ichor/business/domain/inventory/inventorytransactionbus/stores/inventorytransactiondb"
+	"github.com/timmaaaz/ichor/business/domain/labels/labelbus"
+	"github.com/timmaaaz/ichor/business/domain/labels/labelbus/stores/labeldb"
 	"github.com/timmaaaz/ichor/business/domain/inventory/cyclecountitembus"
 	"github.com/timmaaaz/ichor/business/domain/inventory/cyclecountitembus/stores/cyclecountitemdb"
 	"github.com/timmaaaz/ichor/business/domain/inventory/cyclecountsessionbus"
@@ -277,6 +279,9 @@ type BusDomain struct {
 	CycleCountSession    *cyclecountsessionbus.Business
 	CycleCountItem       *cyclecountitembus.Business
 
+	// Labels
+	Label *labelbus.Business
+
 	// Order
 	OrderFulfillmentStatus    *orderfulfillmentstatusbus.Business
 	LineItemFulfillmentStatus *lineitemfulfillmentstatusbus.Business
@@ -395,6 +400,11 @@ func newBusDomains(log *logger.Logger, db *sqlx.DB) BusDomain {
 	cycleCountSessionBus := cyclecountsessionbus.NewBusiness(log, delegate, cyclecountsessiondb.NewStore(log, db))
 	cycleCountItemBus := cyclecountitembus.NewBusiness(log, delegate, cyclecountitemdb.NewStore(log, db))
 
+	// Labels — printer is nil at the BusDomain layer; tests that exercise
+	// printing inject a recording printer through the API stack via
+	// mux.Config.LabelPrinter. Direct bus-level tests do not print.
+	labelBus := labelbus.NewBusiness(log, delegate, labeldb.NewStore(log, db), nil)
+
 	// Orders
 	orderFulfillmentStatusBus := orderfulfillmentstatusbus.NewBusiness(log, delegate, orderfulfillmentstatusdb.NewStore(log, db))
 	lineItemFulfillmentStatusBus := lineitemfulfillmentstatusbus.NewBusiness(log, delegate, lineitemfulfillmentstatusdb.NewStore(log, db))
@@ -482,6 +492,7 @@ func newBusDomains(log *logger.Logger, db *sqlx.DB) BusDomain {
 		PickTask:                    pickTaskBus,
 		CycleCountSession:           cycleCountSessionBus,
 		CycleCountItem:              cycleCountItemBus,
+		Label:                       labelBus,
 		OrderFulfillmentStatus:      orderFulfillmentStatusBus,
 		LineItemFulfillmentStatus:   lineItemFulfillmentStatusBus,
 		Order:                       ordersBus,

--- a/business/sdk/dbtest/seedFrontend.go
+++ b/business/sdk/dbtest/seedFrontend.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
+	"github.com/timmaaaz/ichor/business/domain/labels/labelbus"
+	"github.com/timmaaaz/ichor/business/domain/labels/labelbus/stores/labeldb"
+	"github.com/timmaaaz/ichor/business/sdk/delegate"
 	"github.com/timmaaaz/ichor/business/sdk/sqldb"
 	"github.com/timmaaaz/ichor/foundation/logger"
 )
@@ -52,6 +55,11 @@ func InsertSeedData(log *logger.Logger, cfg sqldb.Config) error {
 
 	if err := seedAssets(ctx, busDomain, foundation); err != nil {
 		return fmt.Errorf("seeding assets: %w", err)
+	}
+
+	labelBus := labelbus.NewBusiness(log, delegate.New(log), labeldb.NewStore(log, db), nil)
+	if err := seedLabels(ctx, labelBus); err != nil {
+		return fmt.Errorf("seed labels: %w", err)
 	}
 
 	products, err := seedProducts(ctx, busDomain, geoHR, foundation)

--- a/business/sdk/dbtest/seedFrontend.go
+++ b/business/sdk/dbtest/seedFrontend.go
@@ -5,9 +5,6 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
-	"github.com/timmaaaz/ichor/business/domain/labels/labelbus"
-	"github.com/timmaaaz/ichor/business/domain/labels/labelbus/stores/labeldb"
-	"github.com/timmaaaz/ichor/business/sdk/delegate"
 	"github.com/timmaaaz/ichor/business/sdk/sqldb"
 	"github.com/timmaaaz/ichor/foundation/logger"
 )
@@ -57,8 +54,7 @@ func InsertSeedData(log *logger.Logger, cfg sqldb.Config) error {
 		return fmt.Errorf("seeding assets: %w", err)
 	}
 
-	labelBus := labelbus.NewBusiness(log, delegate.New(log), labeldb.NewStore(log, db), nil)
-	if err := seedLabels(ctx, labelBus); err != nil {
+	if err := seedLabels(ctx, busDomain.Label); err != nil {
 		return fmt.Errorf("seed labels: %w", err)
 	}
 

--- a/business/sdk/dbtest/seed_labels.go
+++ b/business/sdk/dbtest/seed_labels.go
@@ -1,0 +1,57 @@
+package dbtest
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/timmaaaz/ichor/business/domain/labels/labelbus"
+)
+
+// detNamespace matches the Manitowoc generator's UUID v5 namespace.
+// Using the same namespace guarantees label codes produce byte-identical
+// UUIDs across `make reseed-frontend` invocations and across builds.
+var detNamespace = uuid.MustParse("deadbeef-dead-beef-dead-beefdeadbeef")
+
+// detUUID returns a UUID v5 derived from a stable key string.
+func detUUID(key string) uuid.UUID {
+	return uuid.NewSHA1(detNamespace, []byte(key))
+}
+
+// seedLabels inserts the 39-label Phase 1 catalog (19 locations + 20 totes)
+// with deterministic UUIDs. Matches spec §3.3.
+func seedLabels(ctx context.Context, bus *labelbus.Business) error {
+	entries := []struct {
+		code, typ string
+	}{
+		{"RCV-01", labelbus.TypeLocation}, {"RCV-02", labelbus.TypeLocation},
+		{"QA-01", labelbus.TypeLocation},
+		{"STG-A01", labelbus.TypeLocation}, {"STG-A02", labelbus.TypeLocation}, {"STG-A03", labelbus.TypeLocation},
+		{"STG-B01", labelbus.TypeLocation}, {"STG-B02", labelbus.TypeLocation}, {"STG-B03", labelbus.TypeLocation},
+		{"STG-C01", labelbus.TypeLocation}, {"STG-C02", labelbus.TypeLocation}, {"STG-C03", labelbus.TypeLocation},
+		{"PCK-01", labelbus.TypeLocation}, {"PCK-02", labelbus.TypeLocation}, {"PCK-03", labelbus.TypeLocation},
+		{"PKG-01", labelbus.TypeLocation}, {"PKG-02", labelbus.TypeLocation},
+		{"SHP-01", labelbus.TypeLocation}, {"SHP-02", labelbus.TypeLocation},
+	}
+	for i := 1; i <= 20; i++ {
+		entries = append(entries, struct{ code, typ string }{
+			code: fmt.Sprintf("TOTE-%03d", i),
+			typ:  labelbus.TypeTote,
+		})
+	}
+	if len(entries) != 39 {
+		return fmt.Errorf("expected 39 seed entries, got %d", len(entries))
+	}
+	for _, e := range entries {
+		lc := labelbus.LabelCatalog{
+			ID:          detUUID("label:" + e.code),
+			Code:        e.code,
+			Type:        e.typ,
+			PayloadJSON: "{}",
+		}
+		if err := bus.SeedCreate(ctx, lc); err != nil {
+			return fmt.Errorf("seedcreate %s: %w", e.code, err)
+		}
+	}
+	return nil
+}

--- a/business/sdk/migrate/sql/migrate.sql
+++ b/business/sdk/migrate/sql/migrate.sql
@@ -2433,3 +2433,15 @@ CREATE TABLE core.user_preferences (
 );
 
 CREATE INDEX idx_user_preferences_user_id ON core.user_preferences(user_id);
+
+-- Version: 2.29
+-- Description: Phase 0b — label_catalog for seedable label definitions.
+CREATE TABLE inventory.label_catalog (
+    id            UUID PRIMARY KEY,
+    code          VARCHAR(32) NOT NULL UNIQUE,
+    type          VARCHAR(16) NOT NULL,
+    entity_ref    VARCHAR(64) NULL,
+    payload_json  TEXT NOT NULL DEFAULT '{}',
+    created_date  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_label_catalog_type ON inventory.label_catalog(type);

--- a/business/sdk/migrate/sql/migrate.sql
+++ b/business/sdk/migrate/sql/migrate.sql
@@ -2440,7 +2440,7 @@ CREATE TABLE inventory.label_catalog (
     id            UUID PRIMARY KEY,
     code          VARCHAR(32) NOT NULL UNIQUE,
     type          VARCHAR(16) NOT NULL,
-    entity_ref    VARCHAR(64) NULL,
+    entity_ref    VARCHAR(128) NULL,
     payload_json  TEXT NOT NULL DEFAULT '{}',
     created_date  TIMESTAMPTZ NOT NULL DEFAULT now()
 );

--- a/business/sdk/migrate/sql/seed.sql
+++ b/business/sdk/migrate/sql/seed.sql
@@ -514,6 +514,7 @@ INSERT INTO core.table_access (id, role_id, table_name, can_create, can_read, ca
     (gen_random_uuid(), '54bb2165-71e1-41a6-af3e-7da4a0e1e2c1', 'inventory.inventory_items', true, true, true, true),
     (gen_random_uuid(), '54bb2165-71e1-41a6-af3e-7da4a0e1e2c1', 'inventory.inventory_locations', true, true, true, true),
     (gen_random_uuid(), '54bb2165-71e1-41a6-af3e-7da4a0e1e2c1', 'inventory.inventory_transactions', true, true, true, true),
+    (gen_random_uuid(), '54bb2165-71e1-41a6-af3e-7da4a0e1e2c1', 'inventory.label_catalog', true, true, true, true),
     (gen_random_uuid(), '54bb2165-71e1-41a6-af3e-7da4a0e1e2c1', 'inventory.lot_trackings', true, true, true, true),
     (gen_random_uuid(), '54bb2165-71e1-41a6-af3e-7da4a0e1e2c1', 'inventory.lot_locations', true, true, true, true),
     (gen_random_uuid(), '54bb2165-71e1-41a6-af3e-7da4a0e1e2c1', 'inventory.pick_tasks', true, true, true, true),
@@ -600,6 +601,8 @@ INSERT INTO core.table_access (id, role_id, table_name, can_create, can_read, ca
     (gen_random_uuid(), 'b0000000-0000-4000-8000-000000000001', 'inventory.inventory_transactions', true, true, false, false),
     -- Inventory adjustments: created by cycle count session completion
     (gen_random_uuid(), 'b0000000-0000-4000-8000-000000000001', 'inventory.inventory_adjustments', true, true, true, false),
+    -- Label catalog: read-only access for printing (no catalog modification)
+    (gen_random_uuid(), 'b0000000-0000-4000-8000-000000000001', 'inventory.label_catalog', false, true, false, false),
     -- Read-only tables for scan and context
     (gen_random_uuid(), 'b0000000-0000-4000-8000-000000000001', 'inventory.inventory_locations', false, true, false, false),
     (gen_random_uuid(), 'b0000000-0000-4000-8000-000000000001', 'inventory.serial_numbers', false, true, false, false),


### PR DESCRIPTION
## Summary
- New domain slice: `business/domain/labels/labelbus` + `app/domain/labels/labelapp` + `api/domain/http/labels/labelapi`
- ZPL templates ported from `src/utils/zpl/*.ts` to Go (byte-equivalent via snapshot tests) + new location + tote templates
- `tcpprint` package: `net.Dial` TCP write to `:9100` with context deadline, one retry on dial failure with 250 ms backoff
- `inventory.label_catalog` migration (`2.29`)
- 39-label Phase 1 catalog seeded with deterministic UUID v5 (deadbeef namespace, `"label:" + code`) — reseed-byte-identical
- `POST /v1/labels/print { label_id, copies? }` — catalog labels
- `POST /v1/labels/render-print { type, payload, copies? }` — transaction labels (per-PO receiving, per-order pick); no catalog row created
- `GET /v1/labels?type=...` — type-filtered list for the future admin UI
- End-to-end physical print verified: `status:204` in 13.9 ms, `label printed code=TOTE-001 bytes=82`, one 2"×1" label prints on the GK420t at `172.16.60.116:9100`

## Phase 0 sub-phase
0b (backend). Frontend rewire lands in PR B on the Vue repo after this merges.

## Linked
- Spec: `docs/superpowers/specs/2026-04-14-floor-physical-warehouse-testing-design.md#32-label-subsystem-supersedes-2026-04-13-decision`
- Plan: `docs/superpowers/plans/floor-physical-warehouse-testing/phase-0b-label-subsystem.md`
- Depends on: PR #121 (0a printer env wiring) — merged as `3e985f39`

## Test plan
- [x] 4 ZPL template snapshot tests green (receiving, pick, location, tote — byte-equivalent to captured TS output)
- [x] `tcpprint` integration test green (`net.Listen` fake-server + dial-failure path)
- [x] `labeldb` integration test green (Create + QueryByCode round-trip + DuplicateCode path)
- [x] `labelapp` unit tests green (8 cases: Print happy path, multi-copy, not-found → NotFound errs, bad UUID, printer failure, render-print happy, render-print ZPL content, render-print bad type)
- [x] `make reseed-frontend` twice → `diff` of `label_catalog` rows = empty
- [x] `curl POST /v1/labels/print` → 204 + physical label prints on GK420t
- [x] TC77 scan decodes to `TOTE-001` — confirmed 2026-04-16

## Review tier
**Heavy** — pattern-establishing infrastructure, external I/O, security surface.

### Reviewer focus areas
1. **`tcpprint.Printer.SendZPL`** — context deadline plumbing, connection leak on retry path, write-deadline math, 250 ms backoff rationale
2. **`labelbus.Render`** — JSON unmarshal error wrapping, unknown-type error path, JSON tag mirroring TS field names (so frontend payloads pass through unchanged)
3. **Seeder determinism** — confirm `uuid.NewSHA1(deadbeef, "label:"+code)` is used (not `uuid.New()`); `SeedCreate` escape hatch vs `Create` which would overwrite the deterministic ID
4. **`labelapi.print` / `renderPrint` input validation** — UUID parse, required fields, `oneof=receiving pick` on RenderPrintRequest.Type, copies `min=1,max=100` cap; confirm no ZPL byte leaks from user-controllable fields (EntityRef, PayloadJSON)
5. **Route registration** — `mid.Authenticate(cfg.AuthClient)` applied consistently with assetapi; `mux.Config.PrinterIP` / `PrinterPort` threading from `main.go` → `all.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
