### PR TITLE
phase-0: 0c — identifier migrations

### DIFF
--- a/api/cmd/services/ichor/tests/data/seed_test.go
+++ b/api/cmd/services/ichor/tests/data/seed_test.go
@@ -870,12 +870,7 @@ func insertSeedData(db *dbtest.Database, ath *auth.Auth) (apitest.SeedData, erro
 		return apitest.SeedData{}, fmt.Errorf("seeding zones : %w", err)
 	}
 
-	zoneIDs := make([]uuid.UUID, len(zones))
-	for i, z := range zones {
-		zoneIDs[i] = z.ZoneID
-	}
-
-	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 25, warehouseIDs, zoneIDs, busDomain.InventoryLocation)
+	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 25, warehouseIDs, zones, busDomain.InventoryLocation)
 	if err != nil {
 		return apitest.SeedData{}, fmt.Errorf("seeding inventory locations : %w", err)
 	}

--- a/api/cmd/services/ichor/tests/floor/directedworkapi/seed_test.go
+++ b/api/cmd/services/ichor/tests/floor/directedworkapi/seed_test.go
@@ -116,12 +116,7 @@ func insertSeedData(db *dbtest.Database, ath *auth.Auth) (DirectedWorkSeedData, 
 	if err != nil {
 		return DirectedWorkSeedData{}, fmt.Errorf("seeding zones: %w", err)
 	}
-	zoneIDs := make([]uuid.UUID, len(zones))
-	for i, z := range zones {
-		zoneIDs[i] = z.ZoneID
-	}
-
-	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 1, warehouseIDs, zoneIDs, busDomain.InventoryLocation)
+	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 1, warehouseIDs, zones, busDomain.InventoryLocation)
 	if err != nil {
 		return DirectedWorkSeedData{}, fmt.Errorf("seeding inventory locations: %w", err)
 	}

--- a/api/cmd/services/ichor/tests/formdata/formdataapi/seed_test.go
+++ b/api/cmd/services/ichor/tests/formdata/formdataapi/seed_test.go
@@ -176,12 +176,7 @@ func insertSeedData(db *dbtest.Database, ath *auth.Auth) (apitest.SeedData, erro
 		return apitest.SeedData{}, fmt.Errorf("seeding zones : %w", err)
 	}
 
-	zoneIDs := make([]uuid.UUID, len(zones))
-	for i, z := range zones {
-		zoneIDs[i] = z.ZoneID
-	}
-
-	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 25, warehouseIDs, zoneIDs, busDomain.InventoryLocation)
+	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 25, warehouseIDs, zones, busDomain.InventoryLocation)
 	if err != nil {
 		return apitest.SeedData{}, fmt.Errorf("seeding inventory locations : %w", err)
 	}

--- a/api/cmd/services/ichor/tests/inventory/cyclecountitemapi/seed_test.go
+++ b/api/cmd/services/ichor/tests/inventory/cyclecountitemapi/seed_test.go
@@ -103,12 +103,7 @@ func insertSeedData(db *dbtest.Database, ath *auth.Auth) (apitest.SeedData, erro
 	if err != nil {
 		return apitest.SeedData{}, fmt.Errorf("seeding zones: %w", err)
 	}
-	zoneIDs := make([]uuid.UUID, len(zones))
-	for i, z := range zones {
-		zoneIDs[i] = z.ZoneID
-	}
-
-	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 2, warehouseIDs, zoneIDs, busDomain.InventoryLocation)
+	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 2, warehouseIDs, zones, busDomain.InventoryLocation)
 	if err != nil {
 		return apitest.SeedData{}, fmt.Errorf("seeding inventory locations: %w", err)
 	}

--- a/api/cmd/services/ichor/tests/inventory/cyclecountitemapi/update_test.go
+++ b/api/cmd/services/ichor/tests/inventory/cyclecountitemapi/update_test.go
@@ -26,6 +26,7 @@ func update200(sd apitest.SeedData) []apitest.Table {
 			GotResp: &cyclecountitemapp.CycleCountItem{},
 			ExpResp: &cyclecountitemapp.CycleCountItem{
 				ID:              sd.CycleCountItems[0].ID,
+				ItemCode:        sd.CycleCountItems[0].ItemCode,
 				SessionID:       sd.CycleCountItems[0].SessionID,
 				ProductID:       sd.CycleCountItems[0].ProductID,
 				LocationID:      sd.CycleCountItems[0].LocationID,
@@ -63,6 +64,7 @@ func update200(sd apitest.SeedData) []apitest.Table {
 			GotResp: &cyclecountitemapp.CycleCountItem{},
 			ExpResp: &cyclecountitemapp.CycleCountItem{
 				ID:              sd.CycleCountItems[1].ID,
+				ItemCode:        sd.CycleCountItems[1].ItemCode,
 				SessionID:       sd.CycleCountItems[1].SessionID,
 				ProductID:       sd.CycleCountItems[1].ProductID,
 				LocationID:      sd.CycleCountItems[1].LocationID,

--- a/api/cmd/services/ichor/tests/inventory/cyclecountsessionapi/seed_test.go
+++ b/api/cmd/services/ichor/tests/inventory/cyclecountsessionapi/seed_test.go
@@ -205,12 +205,7 @@ func insertCompleteFlowSeedData(db *dbtest.Database, ath *auth.Auth) (apitest.Se
 	if err != nil {
 		return apitest.SeedData{}, fmt.Errorf("seeding zones: %w", err)
 	}
-	zoneIDs := make([]uuid.UUID, len(zones))
-	for i, z := range zones {
-		zoneIDs[i] = z.ZoneID
-	}
-
-	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 2, warehouseIDs, zoneIDs, busDomain.InventoryLocation)
+	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 2, warehouseIDs, zones, busDomain.InventoryLocation)
 	if err != nil {
 		return apitest.SeedData{}, fmt.Errorf("seeding inventory locations: %w", err)
 	}

--- a/api/cmd/services/ichor/tests/inventory/inventoryadjustmentapi/seed_test.go
+++ b/api/cmd/services/ichor/tests/inventory/inventoryadjustmentapi/seed_test.go
@@ -106,12 +106,7 @@ func insertSeedData(db *dbtest.Database, ath *auth.Auth) (apitest.SeedData, erro
 		return apitest.SeedData{}, fmt.Errorf("seeding zones : %w", err)
 	}
 
-	zoneIDs := make([]uuid.UUID, len(zones))
-	for i, z := range zones {
-		zoneIDs[i] = z.ZoneID
-	}
-
-	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 25, warehouseIDs, zoneIDs, busDomain.InventoryLocation)
+	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 25, warehouseIDs, zones, busDomain.InventoryLocation)
 	if err != nil {
 		return apitest.SeedData{}, fmt.Errorf("seeding inventory locations : %w", err)
 	}

--- a/api/cmd/services/ichor/tests/inventory/inventoryitemapi/seed_test.go
+++ b/api/cmd/services/ichor/tests/inventory/inventoryitemapi/seed_test.go
@@ -156,12 +156,7 @@ func insertSeedData(db *dbtest.Database, ath *auth.Auth) (apitest.SeedData, erro
 		return apitest.SeedData{}, fmt.Errorf("seeding zones : %w", err)
 	}
 
-	zoneIDs := make([]uuid.UUID, len(zones))
-	for i, z := range zones {
-		zoneIDs[i] = z.ZoneID
-	}
-
-	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 25, warehouseIDs, zoneIDs, busDomain.InventoryLocation)
+	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 25, warehouseIDs, zones, busDomain.InventoryLocation)
 	if err != nil {
 		return apitest.SeedData{}, fmt.Errorf("seeding inventory locations : %w", err)
 	}

--- a/api/cmd/services/ichor/tests/inventory/inventorylocationapi/seed_test.go
+++ b/api/cmd/services/ichor/tests/inventory/inventorylocationapi/seed_test.go
@@ -98,12 +98,7 @@ func insertSeedData(db *dbtest.Database, ath *auth.Auth) (apitest.SeedData, erro
 		return apitest.SeedData{}, fmt.Errorf("seeding zones : %w", err)
 	}
 
-	zoneIDs := make([]uuid.UUID, len(zones))
-	for i, z := range zones {
-		zoneIDs[i] = z.ZoneID
-	}
-
-	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 25, warehouseIDs, zoneIDs, busDomain.InventoryLocation)
+	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 25, warehouseIDs, zones, busDomain.InventoryLocation)
 	if err != nil {
 		return apitest.SeedData{}, fmt.Errorf("seeding inventory locations : %w", err)
 	}

--- a/api/cmd/services/ichor/tests/inventory/inventorytransactionapi/seed_test.go
+++ b/api/cmd/services/ichor/tests/inventory/inventorytransactionapi/seed_test.go
@@ -106,12 +106,7 @@ func insertSeedData(db *dbtest.Database, ath *auth.Auth) (apitest.SeedData, erro
 		return apitest.SeedData{}, fmt.Errorf("seeding zones : %w", err)
 	}
 
-	zoneIDs := make([]uuid.UUID, len(zones))
-	for i, z := range zones {
-		zoneIDs[i] = z.ZoneID
-	}
-
-	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 25, warehouseIDs, zoneIDs, busDomain.InventoryLocation)
+	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 25, warehouseIDs, zones, busDomain.InventoryLocation)
 	if err != nil {
 		return apitest.SeedData{}, fmt.Errorf("seeding inventory locations : %w", err)
 	}

--- a/api/cmd/services/ichor/tests/inventory/lotlocationapi/seed_test.go
+++ b/api/cmd/services/ichor/tests/inventory/lotlocationapi/seed_test.go
@@ -191,12 +191,7 @@ func insertSeedData(db *dbtest.Database, ath *auth.Auth) (apitest.SeedData, erro
 		return apitest.SeedData{}, fmt.Errorf("seeding zones : %w", err)
 	}
 
-	zoneIDs := make([]uuid.UUID, len(zones))
-	for i, z := range zones {
-		zoneIDs[i] = z.ZoneID
-	}
-
-	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 10, warehouseIDs, zoneIDs, busDomain.InventoryLocation)
+	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 10, warehouseIDs, zones, busDomain.InventoryLocation)
 	if err != nil {
 		return apitest.SeedData{}, fmt.Errorf("seeding inventory locations : %w", err)
 	}

--- a/api/cmd/services/ichor/tests/inventory/picktaskapi/seed_test.go
+++ b/api/cmd/services/ichor/tests/inventory/picktaskapi/seed_test.go
@@ -124,12 +124,7 @@ func insertSeedData(db *dbtest.Database, ath *auth.Auth) (apitest.SeedData, erro
 		return apitest.SeedData{}, fmt.Errorf("seeding zones : %w", err)
 	}
 
-	zoneIDs := make([]uuid.UUID, len(zones))
-	for i, z := range zones {
-		zoneIDs[i] = z.ZoneID
-	}
-
-	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 5, warehouseIDs, zoneIDs, busDomain.InventoryLocation)
+	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 5, warehouseIDs, zones, busDomain.InventoryLocation)
 	if err != nil {
 		return apitest.SeedData{}, fmt.Errorf("seeding inventory locations : %w", err)
 	}

--- a/api/cmd/services/ichor/tests/inventory/picktaskapi/update_test.go
+++ b/api/cmd/services/ichor/tests/inventory/picktaskapi/update_test.go
@@ -31,6 +31,7 @@ func update200(sd apitest.SeedData) []apitest.Table {
 			GotResp: &picktaskapp.PickTask{},
 			ExpResp: &picktaskapp.PickTask{
 				ID:                   sd.PickTasks[0].ID,
+				TaskNumber:           sd.PickTasks[0].TaskNumber,
 				SalesOrderID:         sd.PickTasks[0].SalesOrderID,
 				SalesOrderLineItemID: sd.PickTasks[0].SalesOrderLineItemID,
 				ProductID:            sd.PickTasks[0].ProductID,

--- a/api/cmd/services/ichor/tests/inventory/putawaytaskapi/seed_test.go
+++ b/api/cmd/services/ichor/tests/inventory/putawaytaskapi/seed_test.go
@@ -104,12 +104,7 @@ func insertSeedData(db *dbtest.Database, ath *auth.Auth) (apitest.SeedData, erro
 		return apitest.SeedData{}, fmt.Errorf("seeding zones : %w", err)
 	}
 
-	zoneIDs := make([]uuid.UUID, len(zones))
-	for i, z := range zones {
-		zoneIDs[i] = z.ZoneID
-	}
-
-	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 5, warehouseIDs, zoneIDs, busDomain.InventoryLocation)
+	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 5, warehouseIDs, zones, busDomain.InventoryLocation)
 	if err != nil {
 		return apitest.SeedData{}, fmt.Errorf("seeding inventory locations : %w", err)
 	}

--- a/api/cmd/services/ichor/tests/inventory/scanapi/seed_test.go
+++ b/api/cmd/services/ichor/tests/inventory/scanapi/seed_test.go
@@ -158,12 +158,7 @@ func insertSeedData(db *dbtest.Database, ath *auth.Auth) (apitest.SeedData, erro
 		return apitest.SeedData{}, fmt.Errorf("seeding zones : %w", err)
 	}
 
-	zoneIDs := make([]uuid.UUID, len(zones))
-	for i, z := range zones {
-		zoneIDs[i] = z.ZoneID
-	}
-
-	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 25, warehouseIDs, zoneIDs, busDomain.InventoryLocation)
+	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 25, warehouseIDs, zones, busDomain.InventoryLocation)
 	if err != nil {
 		return apitest.SeedData{}, fmt.Errorf("seeding inventory locations : %w", err)
 	}

--- a/api/cmd/services/ichor/tests/inventory/serialnumberapi/seed_test.go
+++ b/api/cmd/services/ichor/tests/inventory/serialnumberapi/seed_test.go
@@ -157,12 +157,7 @@ func insertSeedData(db *dbtest.Database, ath *auth.Auth) (apitest.SeedData, erro
 		return apitest.SeedData{}, fmt.Errorf("seeding zones : %w", err)
 	}
 
-	zoneIDs := make([]uuid.UUID, len(zones))
-	for i, z := range zones {
-		zoneIDs[i] = z.ZoneID
-	}
-
-	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 25, warehouseIDs, zoneIDs, busDomain.InventoryLocation)
+	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 25, warehouseIDs, zones, busDomain.InventoryLocation)
 	if err != nil {
 		return apitest.SeedData{}, fmt.Errorf("seeding inventory locations : %w", err)
 	}

--- a/api/cmd/services/ichor/tests/inventory/supervisorkpiapi/seed_test.go
+++ b/api/cmd/services/ichor/tests/inventory/supervisorkpiapi/seed_test.go
@@ -130,12 +130,7 @@ func insertSeedData(db *dbtest.Database, ath *auth.Auth) (apitest.SeedData, erro
 		return apitest.SeedData{}, fmt.Errorf("seeding zones : %w", err)
 	}
 
-	zoneIDs := make([]uuid.UUID, len(zones))
-	for i, z := range zones {
-		zoneIDs[i] = z.ZoneID
-	}
-
-	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 5, warehouseIDs, zoneIDs, busDomain.InventoryLocation)
+	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 5, warehouseIDs, zones, busDomain.InventoryLocation)
 	if err != nil {
 		return apitest.SeedData{}, fmt.Errorf("seeding inventory locations : %w", err)
 	}

--- a/api/cmd/services/ichor/tests/inventory/transferorderapi/seed_test.go
+++ b/api/cmd/services/ichor/tests/inventory/transferorderapi/seed_test.go
@@ -126,12 +126,7 @@ func insertSeedData(db *dbtest.Database, ath *auth.Auth) (apitest.SeedData, erro
 		return apitest.SeedData{}, fmt.Errorf("seeding zones : %w", err)
 	}
 
-	zoneIDs := make([]uuid.UUID, len(zones))
-	for i, z := range zones {
-		zoneIDs[i] = z.ZoneID
-	}
-
-	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 25, warehouseIDs, zoneIDs, busDomain.InventoryLocation)
+	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 25, warehouseIDs, zones, busDomain.InventoryLocation)
 	if err != nil {
 		return apitest.SeedData{}, fmt.Errorf("seeding inventory locations : %w", err)
 	}

--- a/api/cmd/services/ichor/tests/inventory/transferorderapi/update_test.go
+++ b/api/cmd/services/ichor/tests/inventory/transferorderapi/update_test.go
@@ -37,6 +37,8 @@ func update200(sd apitest.SeedData) []apitest.Table {
 			},
 			GotResp: &transferorderapp.TransferOrder{},
 			ExpResp: &transferorderapp.TransferOrder{
+				TransferID:     sd.TransferOrders[1].TransferID,
+				TransferNumber: sd.TransferOrders[1].TransferNumber,
 				ProductID:      sd.Products[0].ProductID,
 				FromLocationID: sd.InventoryLocations[0].LocationID,
 				ToLocationID:   sd.InventoryLocations[2].LocationID,
@@ -46,7 +48,6 @@ func update200(sd apitest.SeedData) []apitest.Table {
 				Status:         "pending",
 				TransferDate:   now.Format(timeutil.FORMAT),
 				CreatedDate:    sd.TransferOrders[1].CreatedDate,
-				TransferID:     sd.TransferOrders[1].TransferID,
 			},
 			CmpFunc: func(got, exp any) string {
 				gotResp, exists := got.(*transferorderapp.TransferOrder)

--- a/api/cmd/services/ichor/tests/inventory/zoneapi/update_test.go
+++ b/api/cmd/services/ichor/tests/inventory/zoneapi/update_test.go
@@ -30,6 +30,7 @@ func update200(sd apitest.SeedData) []apitest.Table {
 			ExpResp: &zoneapp.Zone{
 				WarehouseID: sd.Warehouses[0].ID,
 				Name:        "updated name",
+				ZoneCode:    sd.Zones[0].ZoneCode,
 				Description: "updated description",
 				CreatedDate: sd.Zones[0].CreatedDate,
 				ZoneID:      sd.Zones[0].ZoneID,

--- a/api/cmd/services/ichor/tests/procurement/purchaseorderapi/seed_test.go
+++ b/api/cmd/services/ichor/tests/procurement/purchaseorderapi/seed_test.go
@@ -152,13 +152,8 @@ func insertSeedData(db *dbtest.Database, ath *auth.Auth) (apitest.SeedData, erro
 		return apitest.SeedData{}, fmt.Errorf("seeding zones: %w", err)
 	}
 
-	zoneIDs := make([]uuid.UUID, len(zones))
-	for i, z := range zones {
-		zoneIDs[i] = z.ZoneID
-	}
-
 	// Seed inventory locations
-	locations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 5, warehouseIDs, zoneIDs, busDomain.InventoryLocation)
+	locations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 5, warehouseIDs, zones, busDomain.InventoryLocation)
 	if err != nil {
 		return apitest.SeedData{}, fmt.Errorf("seeding inventory locations: %w", err)
 	}

--- a/api/cmd/services/ichor/tests/procurement/purchaseorderlineitemapi/seed_test.go
+++ b/api/cmd/services/ichor/tests/procurement/purchaseorderlineitemapi/seed_test.go
@@ -215,13 +215,8 @@ func insertSeedData(db *dbtest.Database, ath *auth.Auth) (apitest.SeedData, erro
 		return apitest.SeedData{}, fmt.Errorf("seeding zones: %w", err)
 	}
 
-	zoneIDs := make([]uuid.UUID, len(zones))
-	for i, z := range zones {
-		zoneIDs[i] = z.ZoneID
-	}
-
 	// Seed inventory locations
-	locations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 5, warehouseIDs, zoneIDs, busDomain.InventoryLocation)
+	locations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 5, warehouseIDs, zones, busDomain.InventoryLocation)
 	if err != nil {
 		return apitest.SeedData{}, fmt.Errorf("seeding inventory locations: %w", err)
 	}

--- a/api/cmd/services/ichor/tests/workflow/actionhandlers/inventory_test.go
+++ b/api/cmd/services/ichor/tests/workflow/actionhandlers/inventory_test.go
@@ -110,9 +110,7 @@ func TestReceiveInventoryAction(t *testing.T) {
 	if err != nil {
 		t.Fatalf("seeding zones: %v", err)
 	}
-	zoneIDs := []uuid.UUID{zones[0].ZoneID}
-
-	locations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 1, warehouseIDs, zoneIDs, db.BusDomain.InventoryLocation)
+	locations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 1, warehouseIDs, zones, db.BusDomain.InventoryLocation)
 	if err != nil {
 		t.Fatalf("seeding inventory locations: %v", err)
 	}
@@ -447,9 +445,7 @@ func TestCreatePurchaseOrderAction(t *testing.T) {
 	if err != nil {
 		t.Fatalf("seeding zones: %v", err)
 	}
-	zoneIDs := []uuid.UUID{zones[0].ZoneID}
-
-	locations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 1, warehouseIDs, zoneIDs, db.BusDomain.InventoryLocation)
+	locations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 1, warehouseIDs, zones, db.BusDomain.InventoryLocation)
 	if err != nil {
 		t.Fatalf("seeding inventory locations: %v", err)
 	}

--- a/app/domain/inventory/cyclecountitemapp/model.go
+++ b/app/domain/inventory/cyclecountitemapp/model.go
@@ -32,6 +32,7 @@ type QueryParams struct {
 // CycleCountItem is the app-layer response model. All fields are strings for JSON serialization.
 type CycleCountItem struct {
 	ID              string `json:"id"`
+	ItemCode        string `json:"item_code"`
 	SessionID       string `json:"sessionId"`
 	ProductID       string `json:"productId"`
 	LocationID      string `json:"locationId"`
@@ -52,6 +53,11 @@ func (app CycleCountItem) Encode() ([]byte, string, error) {
 
 // ToAppCycleCountItem converts a bus model to an app-layer response model.
 func ToAppCycleCountItem(bus cyclecountitembus.CycleCountItem) CycleCountItem {
+	itemCode := ""
+	if bus.ItemCode != nil {
+		itemCode = *bus.ItemCode
+	}
+
 	countedQuantity := ""
 	if bus.CountedQuantity != nil {
 		countedQuantity = strconv.Itoa(*bus.CountedQuantity)
@@ -74,6 +80,7 @@ func ToAppCycleCountItem(bus cyclecountitembus.CycleCountItem) CycleCountItem {
 
 	return CycleCountItem{
 		ID:              bus.ID.String(),
+		ItemCode:        itemCode,
 		SessionID:       bus.SessionID.String(),
 		ProductID:       bus.ProductID.String(),
 		LocationID:      bus.LocationID.String(),
@@ -103,7 +110,8 @@ func ToAppCycleCountItems(bus []cyclecountitembus.CycleCountItem) []CycleCountIt
 
 // NewCycleCountItem is the app-layer create request model.
 type NewCycleCountItem struct {
-	SessionID      string `json:"sessionId" validate:"required,min=36,max=36"`
+	ItemCode       *string `json:"item_code" validate:"omitempty,min=1,max=32"`
+	SessionID      string  `json:"sessionId" validate:"required,min=36,max=36"`
 	ProductID      string `json:"productId" validate:"required,min=36,max=36"`
 	LocationID     string `json:"locationId" validate:"required,min=36,max=36"`
 	SystemQuantity string `json:"systemQuantity" validate:"required"`
@@ -141,12 +149,16 @@ func toBusNewCycleCountItem(app NewCycleCountItem) (cyclecountitembus.NewCycleCo
 		return cyclecountitembus.NewCycleCountItem{}, errs.Newf(errs.InvalidArgument, "parse systemQuantity: %s", err)
 	}
 
-	return cyclecountitembus.NewCycleCountItem{
+	dest := cyclecountitembus.NewCycleCountItem{
 		SessionID:      sessionID,
 		ProductID:      productID,
 		LocationID:     locationID,
 		SystemQuantity: systemQuantity,
-	}, nil
+	}
+	if app.ItemCode != nil {
+		dest.ItemCode = app.ItemCode
+	}
+	return dest, nil
 }
 
 // =============================================================================
@@ -155,6 +167,7 @@ func toBusNewCycleCountItem(app NewCycleCountItem) (cyclecountitembus.NewCycleCo
 
 // UpdateCycleCountItem is the app-layer update request model.
 type UpdateCycleCountItem struct {
+	ItemCode        *string `json:"item_code" validate:"omitempty,min=1,max=32"`
 	CountedQuantity *string `json:"countedQuantity" validate:"omitempty"`
 	Status          *string `json:"status" validate:"omitempty"`
 }
@@ -173,6 +186,9 @@ func (app UpdateCycleCountItem) Validate() error {
 func toBusUpdateCycleCountItem(app UpdateCycleCountItem, userID uuid.UUID) (cyclecountitembus.UpdateCycleCountItem, error) {
 	bus := cyclecountitembus.UpdateCycleCountItem{}
 
+	if app.ItemCode != nil {
+		bus.ItemCode = app.ItemCode
+	}
 	if app.CountedQuantity != nil {
 		q, err := strconv.Atoi(*app.CountedQuantity)
 		if err != nil {

--- a/app/domain/inventory/picktaskapp/model.go
+++ b/app/domain/inventory/picktaskapp/model.go
@@ -33,6 +33,7 @@ type QueryParams struct {
 // PickTask is the app-layer response model. All fields are strings for JSON serialization.
 type PickTask struct {
 	ID                   string `json:"id"`
+	TaskNumber           string `json:"task_number"`
 	SalesOrderID         string `json:"sales_order_id"`
 	SalesOrderLineItemID string `json:"sales_order_line_item_id"`
 	ProductID            string `json:"product_id"`
@@ -59,6 +60,11 @@ func (app PickTask) Encode() ([]byte, string, error) {
 
 // ToAppPickTask converts a bus model to an app-layer response model.
 func ToAppPickTask(bus picktaskbus.PickTask) PickTask {
+	taskNumber := ""
+	if bus.TaskNumber != nil {
+		taskNumber = *bus.TaskNumber
+	}
+
 	lotID := ""
 	if bus.LotID != nil {
 		lotID = bus.LotID.String()
@@ -91,6 +97,7 @@ func ToAppPickTask(bus picktaskbus.PickTask) PickTask {
 
 	return PickTask{
 		ID:                   bus.ID.String(),
+		TaskNumber:           taskNumber,
 		SalesOrderID:         bus.SalesOrderID.String(),
 		SalesOrderLineItemID: bus.SalesOrderLineItemID.String(),
 		ProductID:            bus.ProductID.String(),
@@ -127,6 +134,7 @@ func ToAppPickTasks(bus []picktaskbus.PickTask) []PickTask {
 // NewPickTask is the app-layer create request model.
 // CreatedBy is injected from the authenticated user — not accepted from the client.
 type NewPickTask struct {
+	TaskNumber           *string `json:"task_number" validate:"omitempty,min=1,max=32"`
 	SalesOrderID         string  `json:"sales_order_id" validate:"required,min=36,max=36"`
 	SalesOrderLineItemID string  `json:"sales_order_line_item_id" validate:"required,min=36,max=36"`
 	ProductID            string  `json:"product_id" validate:"required,min=36,max=36"`
@@ -191,7 +199,7 @@ func toBusNewPickTask(app NewPickTask, createdBy uuid.UUID) (picktaskbus.NewPick
 		serialID = &id
 	}
 
-	return picktaskbus.NewPickTask{
+	bus := picktaskbus.NewPickTask{
 		SalesOrderID:         salesOrderID,
 		SalesOrderLineItemID: salesOrderLineItemID,
 		ProductID:            productID,
@@ -200,7 +208,13 @@ func toBusNewPickTask(app NewPickTask, createdBy uuid.UUID) (picktaskbus.NewPick
 		LocationID:           locationID,
 		QuantityToPick:       quantityToPick,
 		CreatedBy:            createdBy,
-	}, nil
+	}
+
+	if app.TaskNumber != nil {
+		bus.TaskNumber = app.TaskNumber
+	}
+
+	return bus, nil
 }
 
 // =============================================================================
@@ -209,6 +223,7 @@ func toBusNewPickTask(app NewPickTask, createdBy uuid.UUID) (picktaskbus.NewPick
 
 // UpdatePickTask is the app-layer update request model.
 type UpdatePickTask struct {
+	TaskNumber      *string `json:"task_number" validate:"omitempty,min=1,max=32"`
 	LotID           *string `json:"lot_id" validate:"omitempty,min=36,max=36"`
 	SerialID        *string `json:"serial_id" validate:"omitempty,min=36,max=36"`
 	LocationID      *string `json:"location_id" validate:"omitempty,min=36,max=36"`
@@ -282,6 +297,10 @@ func toBusUpdatePickTask(app UpdatePickTask) (picktaskbus.UpdatePickTask, error)
 
 	if app.ShortPickReason != nil {
 		bus.ShortPickReason = app.ShortPickReason
+	}
+
+	if app.TaskNumber != nil {
+		bus.TaskNumber = app.TaskNumber
 	}
 
 	return bus, nil

--- a/app/domain/inventory/transferorderapp/model.go
+++ b/app/domain/inventory/transferorderapp/model.go
@@ -32,6 +32,7 @@ type QueryParams struct {
 
 type TransferOrder struct {
 	TransferID      string `json:"transfer_id"`
+	TransferNumber  string `json:"transfer_number"`
 	ProductID       string `json:"product_id"`
 	FromLocationID  string `json:"from_location_id"`
 	ToLocationID    string `json:"to_location_id"`
@@ -57,6 +58,11 @@ func (app TransferOrder) Encode() ([]byte, string, error) {
 }
 
 func ToAppTransferOrder(bus transferorderbus.TransferOrder) TransferOrder {
+	transferNumber := ""
+	if bus.TransferNumber != nil {
+		transferNumber = *bus.TransferNumber
+	}
+
 	approvedByID := ""
 	if bus.ApprovedByID != nil {
 		approvedByID = bus.ApprovedByID.String()
@@ -89,6 +95,7 @@ func ToAppTransferOrder(bus transferorderbus.TransferOrder) TransferOrder {
 
 	return TransferOrder{
 		TransferID:      bus.TransferID.String(),
+		TransferNumber:  transferNumber,
 		ProductID:       bus.ProductID.String(),
 		FromLocationID:  bus.FromLocationID.String(),
 		ToLocationID:    bus.ToLocationID.String(),
@@ -118,6 +125,7 @@ func ToAppTransferOrders(bus []transferorderbus.TransferOrder) []TransferOrder {
 }
 
 type NewTransferOrder struct {
+	TransferNumber *string `json:"transfer_number" validate:"omitempty,min=1,max=32"`
 	ProductID      string  `json:"product_id" validate:"required,min=36,max=36"`
 	FromLocationID string  `json:"from_location_id" validate:"required,min=36,max=36"`
 	ToLocationID   string  `json:"to_location_id" validate:"required,min=36,max=36"`
@@ -180,6 +188,7 @@ func toBusNewTransferOrder(app NewTransferOrder) (transferorderbus.NewTransferOr
 	}
 
 	bus := transferorderbus.NewTransferOrder{
+		TransferNumber: app.TransferNumber,
 		ProductID:      productID,
 		FromLocationID: fromLocationID,
 		ToLocationID:   toLocationID,
@@ -193,6 +202,7 @@ func toBusNewTransferOrder(app NewTransferOrder) (transferorderbus.NewTransferOr
 }
 
 type UpdateTransferOrder struct {
+	TransferNumber *string `json:"transfer_number" validate:"omitempty,min=1,max=32"`
 	ProductID      *string `json:"product_id" validate:"omitempty,min=36,max=36"`
 	FromLocationID *string `json:"from_location_id" validate:"omitempty,min=36,max=36"`
 	ToLocationID   *string `json:"to_location_id" validate:"omitempty,min=36,max=36"`
@@ -216,7 +226,8 @@ func (app UpdateTransferOrder) Validate() error {
 
 func toBusUpdateTransferOrder(app UpdateTransferOrder) (transferorderbus.UpdateTransferOrder, error) {
 	bus := transferorderbus.UpdateTransferOrder{
-		Status: app.Status,
+		TransferNumber: app.TransferNumber,
+		Status:         app.Status,
 	}
 
 	if app.ProductID != nil {

--- a/app/domain/inventory/zoneapp/model.go
+++ b/app/domain/inventory/zoneapp/model.go
@@ -27,6 +27,7 @@ type Zone struct {
 	ZoneID      string `json:"zone_id"`
 	WarehouseID string `json:"warehouse_id"`
 	Name        string `json:"name"`
+	ZoneCode    string `json:"zone_code"`
 	Description string `json:"description"`
 	Stage       string `json:"stage"`
 	CreatedDate string `json:"created_date"`
@@ -47,6 +48,9 @@ func ToAppZone(bus zonebus.Zone) Zone {
 		CreatedDate: bus.CreatedDate.Format(timeutil.FORMAT),
 		UpdatedDate: bus.UpdatedDate.Format(timeutil.FORMAT),
 	}
+	if bus.ZoneCode != nil {
+		app.ZoneCode = *bus.ZoneCode
+	}
 	if bus.Stage != nil {
 		app.Stage = bus.Stage.String()
 	}
@@ -62,10 +66,11 @@ func ToAppZones(zones []zonebus.Zone) []Zone {
 }
 
 type NewZone struct {
-	WarehouseID string `json:"warehouse_id" validate:"required,min=36,max=36"`
-	Name        string `json:"name" validate:"required"`
-	Description string `json:"description" validate:"omitempty"`
-	Stage       string `json:"stage" validate:"omitempty"`
+	WarehouseID string  `json:"warehouse_id" validate:"required,min=36,max=36"`
+	Name        string  `json:"name" validate:"required"`
+	ZoneCode    *string `json:"zone_code" validate:"omitempty,min=1,max=16"`
+	Description string  `json:"description" validate:"omitempty"`
+	Stage       string  `json:"stage" validate:"omitempty"`
 }
 
 func (app *NewZone) Decode(data []byte) error {
@@ -92,6 +97,10 @@ func toBusNewZone(app NewZone) (zonebus.NewZone, error) {
 		Description: app.Description,
 	}
 
+	if app.ZoneCode != nil {
+		dest.ZoneCode = app.ZoneCode
+	}
+
 	if app.Stage != "" {
 		st, err := zonebus.ParseStage(app.Stage)
 		if err != nil {
@@ -106,6 +115,7 @@ func toBusNewZone(app NewZone) (zonebus.NewZone, error) {
 type UpdateZone struct {
 	WarehouseID *string `json:"warehouse_id" validate:"omitempty,min=36,max=36"`
 	Name        *string `json:"name" validate:"omitempty"`
+	ZoneCode    *string `json:"zone_code" validate:"omitempty,min=1,max=16"`
 	Description *string `json:"description" validate:"omitempty"`
 	Stage       *string `json:"stage" validate:"omitempty"`
 }
@@ -139,6 +149,10 @@ func toBusUpdateZone(app UpdateZone) (zonebus.UpdateZone, error) {
 
 	if app.Name != nil {
 		dest.Name = app.Name
+	}
+
+	if app.ZoneCode != nil {
+		dest.ZoneCode = app.ZoneCode
 	}
 
 	if app.Stage != nil && *app.Stage != "" {

--- a/business/domain/inventory/cyclecountitembus/cyclecountitembus.go
+++ b/business/domain/inventory/cyclecountitembus/cyclecountitembus.go
@@ -74,6 +74,7 @@ func (b *Business) Create(ctx context.Context, ncci NewCycleCountItem) (CycleCou
 
 	item := CycleCountItem{
 		ID:             uuid.New(),
+		ItemCode:       ncci.ItemCode,
 		SessionID:      ncci.SessionID,
 		ProductID:      ncci.ProductID,
 		LocationID:     ncci.LocationID,
@@ -102,6 +103,9 @@ func (b *Business) Update(ctx context.Context, item CycleCountItem, ucci UpdateC
 
 	before := item
 
+	if ucci.ItemCode != nil {
+		item.ItemCode = ucci.ItemCode
+	}
 	if ucci.CountedQuantity != nil {
 		item.CountedQuantity = ucci.CountedQuantity
 		variance := *ucci.CountedQuantity - item.SystemQuantity

--- a/business/domain/inventory/cyclecountitembus/model.go
+++ b/business/domain/inventory/cyclecountitembus/model.go
@@ -13,6 +13,7 @@ import (
 // Each item records the system quantity, the counted quantity, and the computed variance.
 type CycleCountItem struct {
 	ID               uuid.UUID `json:"id"`
+	ItemCode         *string   `json:"item_code,omitempty"`
 	SessionID        uuid.UUID `json:"session_id"`
 	ProductID        uuid.UUID `json:"product_id"`
 	LocationID       uuid.UUID `json:"location_id"`
@@ -29,6 +30,7 @@ type CycleCountItem struct {
 // NewCycleCountItem contains the information needed to create a new cycle count item.
 // Status is always set to Statuses.Pending by the business layer.
 type NewCycleCountItem struct {
+	ItemCode       *string   `json:"item_code,omitempty"`
 	SessionID      uuid.UUID `json:"session_id"`
 	ProductID      uuid.UUID `json:"product_id"`
 	LocationID     uuid.UUID `json:"location_id"`
@@ -39,6 +41,7 @@ type NewCycleCountItem struct {
 // All fields are optional pointers; nil means "do not update this field."
 // When CountedQuantity is set, Variance is automatically computed by the business layer.
 type UpdateCycleCountItem struct {
+	ItemCode        *string    `json:"item_code,omitempty"`
 	CountedQuantity *int       `json:"counted_quantity,omitempty"`
 	Status          *Status    `json:"status,omitempty"`
 	CountedBy       *uuid.UUID `json:"counted_by,omitempty"`

--- a/business/domain/inventory/cyclecountitembus/stores/cyclecountitemdb/cyclecountitemdb.go
+++ b/business/domain/inventory/cyclecountitembus/stores/cyclecountitemdb/cyclecountitemdb.go
@@ -47,9 +47,9 @@ func (s *Store) NewWithTx(tx sqldb.CommitRollbacker) (cyclecountitembus.Storer, 
 func (s *Store) Create(ctx context.Context, item cyclecountitembus.CycleCountItem) error {
 	const q = `
 	INSERT INTO inventory.cycle_count_items
-		(id, session_id, product_id, location_id, system_quantity, counted_quantity, variance, status, counted_by, counted_date, created_date, updated_date)
+		(id, item_code, session_id, product_id, location_id, system_quantity, counted_quantity, variance, status, counted_by, counted_date, created_date, updated_date)
 	VALUES
-		(:id, :session_id, :product_id, :location_id, :system_quantity, :counted_quantity, :variance, :status, :counted_by, :counted_date, :created_date, :updated_date)
+		(:id, :item_code, :session_id, :product_id, :location_id, :system_quantity, :counted_quantity, :variance, :status, :counted_by, :counted_date, :created_date, :updated_date)
 	`
 
 	if err := sqldb.NamedExecContext(ctx, s.log, s.db, q, toDBCycleCountItem(item)); err != nil {
@@ -70,6 +70,7 @@ func (s *Store) Update(ctx context.Context, item cyclecountitembus.CycleCountIte
 	const q = `
 	UPDATE inventory.cycle_count_items
 	SET
+		item_code        = :item_code,
 		counted_quantity = :counted_quantity,
 		variance         = :variance,
 		status           = :status,
@@ -116,7 +117,7 @@ func (s *Store) Query(ctx context.Context, filter cyclecountitembus.QueryFilter,
 
 	const q = `
 	SELECT
-		id, session_id, product_id, location_id, system_quantity, counted_quantity, variance, status, counted_by, counted_date, created_date, updated_date
+		id, item_code, session_id, product_id, location_id, system_quantity, counted_quantity, variance, status, counted_by, counted_date, created_date, updated_date
 	FROM
 		inventory.cycle_count_items
 	`
@@ -179,7 +180,7 @@ func (s *Store) QueryByID(ctx context.Context, itemID uuid.UUID) (cyclecountitem
 
 	const q = `
 	SELECT
-		id, session_id, product_id, location_id, system_quantity, counted_quantity, variance, status, counted_by, counted_date, created_date, updated_date
+		id, item_code, session_id, product_id, location_id, system_quantity, counted_quantity, variance, status, counted_by, counted_date, created_date, updated_date
 	FROM
 		inventory.cycle_count_items
 	WHERE

--- a/business/domain/inventory/cyclecountitembus/stores/cyclecountitemdb/model.go
+++ b/business/domain/inventory/cyclecountitembus/stores/cyclecountitemdb/model.go
@@ -13,6 +13,7 @@ import (
 // cycleCountItem mirrors the inventory.cycle_count_items DB row.
 type cycleCountItem struct {
 	ID              uuid.UUID      `db:"id"`
+	ItemCode        sql.NullString `db:"item_code"`
 	SessionID       uuid.UUID      `db:"session_id"`
 	ProductID       uuid.UUID      `db:"product_id"`
 	LocationID      uuid.UUID      `db:"location_id"`
@@ -39,6 +40,7 @@ func toBusCycleCountItem(db cycleCountItem) (cyclecountitembus.CycleCountItem, e
 
 	return cyclecountitembus.CycleCountItem{
 		ID:              db.ID,
+		ItemCode:        nulltypes.StringPtr(db.ItemCode),
 		SessionID:       db.SessionID,
 		ProductID:       db.ProductID,
 		LocationID:      db.LocationID,
@@ -73,6 +75,7 @@ func toDBCycleCountItem(bus cyclecountitembus.CycleCountItem) cycleCountItem {
 
 	return cycleCountItem{
 		ID:              bus.ID,
+		ItemCode:        nulltypes.ToNullString(bus.ItemCode),
 		SessionID:       bus.SessionID,
 		ProductID:       bus.ProductID,
 		LocationID:      bus.LocationID,

--- a/business/domain/inventory/cyclecountitembus/testutil.go
+++ b/business/domain/inventory/cyclecountitembus/testutil.go
@@ -13,7 +13,11 @@ func TestNewCycleCountItems(n int, sessionIDs, productIDs, locationIDs []uuid.UU
 	items := make([]NewCycleCountItem, n)
 
 	for i := range n {
+		sessionSerial := (i % len(sessionIDs)) + 1
+		itemSerial := i + 1
+		code := fmt.Sprintf("CC-%03d-%03d", sessionSerial, itemSerial)
 		items[i] = NewCycleCountItem{
+			ItemCode:       &code,
 			SessionID:      sessionIDs[i%len(sessionIDs)],
 			ProductID:      productIDs[i%len(productIDs)],
 			LocationID:     locationIDs[i%len(locationIDs)],

--- a/business/domain/inventory/inventoryadjustmentbus/inventoryadjustmentbus_test.go
+++ b/business/domain/inventory/inventoryadjustmentbus/inventoryadjustmentbus_test.go
@@ -154,12 +154,7 @@ func insertSeedData(busDomain dbtest.BusDomain) (unitest.SeedData, error) {
 		return unitest.SeedData{}, fmt.Errorf("seeding zones : %w", err)
 	}
 
-	zoneIDs := make([]uuid.UUID, len(zones))
-	for i, z := range zones {
-		zoneIDs[i] = z.ZoneID
-	}
-
-	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 25, warehouseIDs, zoneIDs, busDomain.InventoryLocation)
+	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 25, warehouseIDs, zones, busDomain.InventoryLocation)
 	if err != nil {
 		return unitest.SeedData{}, fmt.Errorf("seeding inventory locations : %w", err)
 	}

--- a/business/domain/inventory/inventoryitembus/inventoryitembus_test.go
+++ b/business/domain/inventory/inventoryitembus/inventoryitembus_test.go
@@ -163,12 +163,7 @@ func insertSeedData(busDomain dbtest.BusDomain) (unitest.SeedData, error) {
 		return unitest.SeedData{}, fmt.Errorf("seeding zones : %w", err)
 	}
 
-	zoneIDs := make([]uuid.UUID, len(zones))
-	for i, z := range zones {
-		zoneIDs[i] = z.ZoneID
-	}
-
-	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 25, warehouseIDs, zoneIDs, busDomain.InventoryLocation)
+	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 25, warehouseIDs, zones, busDomain.InventoryLocation)
 	if err != nil {
 		return unitest.SeedData{}, fmt.Errorf("seeding inventory locations : %w", err)
 	}
@@ -495,7 +490,7 @@ func Test_QueryAvailableForAllocation(t *testing.T) {
 		t.Fatalf("seeding zones: %s", err)
 	}
 
-	locations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 3, uuid.UUIDs{warehouses[0].ID}, uuid.UUIDs{zones[0].ZoneID}, bd.InventoryLocation)
+	locations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 3, uuid.UUIDs{warehouses[0].ID}, []zonebus.Zone{zones[0]}, bd.InventoryLocation)
 	if err != nil {
 		t.Fatalf("seeding locations: %s", err)
 	}

--- a/business/domain/inventory/inventorylocationbus/inventorylocationbus_test.go
+++ b/business/domain/inventory/inventorylocationbus/inventorylocationbus_test.go
@@ -99,12 +99,7 @@ func insertSeedData(busDomain dbtest.BusDomain) (unitest.SeedData, error) {
 		return unitest.SeedData{}, fmt.Errorf("seeding zones : %w", err)
 	}
 
-	zoneIDs := make([]uuid.UUID, len(zones))
-	for i, z := range zones {
-		zoneIDs[i] = z.ZoneID
-	}
-
-	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 25, warehouseIDs, zoneIDs, busDomain.InventoryLocation)
+	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 25, warehouseIDs, zones, busDomain.InventoryLocation)
 	if err != nil {
 		return unitest.SeedData{}, fmt.Errorf("seeding inventory locations : %w", err)
 	}

--- a/business/domain/inventory/inventorylocationbus/testutil.go
+++ b/business/domain/inventory/inventorylocationbus/testutil.go
@@ -8,9 +8,10 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/timmaaaz/ichor/business/domain/inventory/inventorylocationbus/types"
+	"github.com/timmaaaz/ichor/business/domain/inventory/zonebus"
 )
 
-func TestNewInventoryLocation(n int, warehouseIDs, zoneIDs []uuid.UUID) []NewInventoryLocation {
+func TestNewInventoryLocation(n int, warehouseIDs []uuid.UUID, zones []zonebus.Zone) []NewInventoryLocation {
 	newInventoryLocations := make([]NewInventoryLocation, n)
 
 	aisles := []string{"A", "B", "C"}
@@ -19,21 +20,27 @@ func TestNewInventoryLocation(n int, warehouseIDs, zoneIDs []uuid.UUID) []NewInv
 	for i := 0; i < n; i++ {
 		idx++
 
-		// Warehouse-realistic codes: A-01-02-03 format.
+		// Warehouse-realistic codes: {ZoneCode}-{Aisle}{Rack}{Shelf}{Bin} format (spec §3.7, user-approved 2026-04-16).
 		// Aisles A/B/C, racks 01-05, shelves 01-04, bins 01-06.
-		// Uses idx (monotonically increasing) to guarantee uniqueness.
+		// Zone prefix comes from the owning zone's ZoneCode (populated by TestNewZone in phase 0c.1).
 		aisle := aisles[idx%3]
 		rack := fmt.Sprintf("%02d", (idx/3)%5+1)
 		shelf := fmt.Sprintf("%02d", (idx/15)%4+1)
 		bin := fmt.Sprintf("%02d", (idx/60)%6+1)
-		locationCode := fmt.Sprintf("%s-%s-%s-%s", aisle, rack, shelf, bin)
+
+		zone := zones[idx%len(zones)]
+		zoneCode := ""
+		if zone.ZoneCode != nil {
+			zoneCode = *zone.ZoneCode
+		}
+		locationCode := fmt.Sprintf("%s-%s%s%s%s", zoneCode, aisle, rack, shelf, bin)
 
 		// Alternate: even indices are pick locations, odd are reserve
 		isPickLocation := i%2 == 0
 
 		newInventoryLocations[i] = NewInventoryLocation{
 			WarehouseID:        warehouseIDs[idx%len(warehouseIDs)],
-			ZoneID:             zoneIDs[idx%len(zoneIDs)],
+			ZoneID:             zone.ZoneID,
 			Aisle:              aisle,
 			Rack:               rack,
 			Shelf:              shelf,
@@ -49,8 +56,8 @@ func TestNewInventoryLocation(n int, warehouseIDs, zoneIDs []uuid.UUID) []NewInv
 	return newInventoryLocations
 }
 
-func TestSeedInventoryLocations(ctx context.Context, n int, warehouseIDs, zoneIDs []uuid.UUID, api *Business) ([]InventoryLocation, error) {
-	newInventoryLocations := TestNewInventoryLocation(n, warehouseIDs, zoneIDs)
+func TestSeedInventoryLocations(ctx context.Context, n int, warehouseIDs []uuid.UUID, zones []zonebus.Zone, api *Business) ([]InventoryLocation, error) {
+	newInventoryLocations := TestNewInventoryLocation(n, warehouseIDs, zones)
 
 	inventoryLocations := make([]InventoryLocation, len(newInventoryLocations))
 

--- a/business/domain/inventory/inventorytransactionbus/inventorytransactionbus_test.go
+++ b/business/domain/inventory/inventorytransactionbus/inventorytransactionbus_test.go
@@ -154,12 +154,7 @@ func insertSeedData(busDomain dbtest.BusDomain) (unitest.SeedData, error) {
 		return unitest.SeedData{}, fmt.Errorf("seeding zones : %w", err)
 	}
 
-	zoneIDs := make([]uuid.UUID, len(zones))
-	for i, z := range zones {
-		zoneIDs[i] = z.ZoneID
-	}
-
-	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 25, warehouseIDs, zoneIDs, busDomain.InventoryLocation)
+	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 25, warehouseIDs, zones, busDomain.InventoryLocation)
 	if err != nil {
 		return unitest.SeedData{}, fmt.Errorf("seeding inventory locations : %w", err)
 	}

--- a/business/domain/inventory/picktaskbus/model.go
+++ b/business/domain/inventory/picktaskbus/model.go
@@ -13,6 +13,7 @@ import (
 // pick QuantityToPick units of ProductID from LocationID to fulfill a sales order line item.
 type PickTask struct {
 	ID                   uuid.UUID  `json:"id"`
+	TaskNumber           *string    `json:"task_number,omitempty"`
 	SalesOrderID         uuid.UUID  `json:"sales_order_id"`
 	SalesOrderLineItemID uuid.UUID  `json:"sales_order_line_item_id"`
 	ProductID            uuid.UUID  `json:"product_id"`
@@ -35,6 +36,7 @@ type PickTask struct {
 // NewPickTask contains the information needed to create a new pick task.
 // Status is always set to Statuses.Pending by the business layer.
 type NewPickTask struct {
+	TaskNumber           *string    `json:"task_number,omitempty"`
 	SalesOrderID         uuid.UUID  `json:"sales_order_id"`
 	SalesOrderLineItemID uuid.UUID  `json:"sales_order_line_item_id"`
 	ProductID            uuid.UUID  `json:"product_id"`
@@ -48,6 +50,7 @@ type NewPickTask struct {
 // UpdatePickTask contains the information that can be changed on a pick task.
 // All fields are optional pointers; nil means "do not update this field."
 type UpdatePickTask struct {
+	TaskNumber      *string    `json:"task_number,omitempty"`
 	LotID           *uuid.UUID `json:"lot_id,omitempty"`
 	SerialID        *uuid.UUID `json:"serial_id,omitempty"`
 	LocationID      *uuid.UUID `json:"location_id,omitempty"`

--- a/business/domain/inventory/picktaskbus/picktaskbus.go
+++ b/business/domain/inventory/picktaskbus/picktaskbus.go
@@ -74,6 +74,7 @@ func (b *Business) Create(ctx context.Context, npt NewPickTask) (PickTask, error
 
 	task := PickTask{
 		ID:                   uuid.New(),
+		TaskNumber:           npt.TaskNumber,
 		SalesOrderID:         npt.SalesOrderID,
 		SalesOrderLineItemID: npt.SalesOrderLineItemID,
 		ProductID:            npt.ProductID,
@@ -106,6 +107,9 @@ func (b *Business) Update(ctx context.Context, task PickTask, upt UpdatePickTask
 
 	before := task
 
+	if upt.TaskNumber != nil {
+		task.TaskNumber = upt.TaskNumber
+	}
 	if upt.LotID != nil {
 		task.LotID = upt.LotID
 	}

--- a/business/domain/inventory/picktaskbus/stores/picktaskdb/model.go
+++ b/business/domain/inventory/picktaskbus/stores/picktaskdb/model.go
@@ -13,6 +13,7 @@ import (
 // pickTask mirrors the inventory.pick_tasks DB row.
 type pickTask struct {
 	ID                   uuid.UUID      `db:"id"`
+	TaskNumber           sql.NullString `db:"task_number"`
 	SalesOrderID         uuid.UUID      `db:"sales_order_id"`
 	SalesOrderLineItemID uuid.UUID      `db:"sales_order_line_item_id"`
 	ProductID            uuid.UUID      `db:"product_id"`
@@ -33,6 +34,12 @@ type pickTask struct {
 }
 
 func toBusPickTask(db pickTask) (picktaskbus.PickTask, error) {
+	var taskNumber *string
+	if db.TaskNumber.Valid {
+		s := db.TaskNumber.String
+		taskNumber = &s
+	}
+
 	var lotID *uuid.UUID
 	if db.LotID.Valid {
 		id := db.LotID.UUID
@@ -67,6 +74,7 @@ func toBusPickTask(db pickTask) (picktaskbus.PickTask, error) {
 
 	return picktaskbus.PickTask{
 		ID:                   db.ID,
+		TaskNumber:           taskNumber,
 		SalesOrderID:         db.SalesOrderID,
 		SalesOrderLineItemID: db.SalesOrderLineItemID,
 		ProductID:            db.ProductID,
@@ -100,6 +108,11 @@ func toBusPickTasks(dbs []pickTask) ([]picktaskbus.PickTask, error) {
 }
 
 func toDBPickTask(bus picktaskbus.PickTask) pickTask {
+	var taskNumber sql.NullString
+	if bus.TaskNumber != nil {
+		taskNumber = sql.NullString{String: *bus.TaskNumber, Valid: true}
+	}
+
 	var lotID uuid.NullUUID
 	if bus.LotID != nil {
 		lotID = uuid.NullUUID{UUID: *bus.LotID, Valid: true}
@@ -127,6 +140,7 @@ func toDBPickTask(bus picktaskbus.PickTask) pickTask {
 
 	return pickTask{
 		ID:                   bus.ID,
+		TaskNumber:           taskNumber,
 		SalesOrderID:         bus.SalesOrderID,
 		SalesOrderLineItemID: bus.SalesOrderLineItemID,
 		ProductID:            bus.ProductID,

--- a/business/domain/inventory/picktaskbus/stores/picktaskdb/picktaskdb.go
+++ b/business/domain/inventory/picktaskbus/stores/picktaskdb/picktaskdb.go
@@ -47,12 +47,12 @@ func (s *Store) NewWithTx(tx sqldb.CommitRollbacker) (picktaskbus.Storer, error)
 func (s *Store) Create(ctx context.Context, task picktaskbus.PickTask) error {
 	const q = `
 	INSERT INTO inventory.pick_tasks
-		(id, sales_order_id, sales_order_line_item_id, product_id, lot_id, serial_id,
+		(id, task_number, sales_order_id, sales_order_line_item_id, product_id, lot_id, serial_id,
 		 location_id, quantity_to_pick, quantity_picked, status,
 		 assigned_to, assigned_at, completed_by, completed_at,
 		 short_pick_reason, created_by, created_date, updated_date)
 	VALUES
-		(:id, :sales_order_id, :sales_order_line_item_id, :product_id, :lot_id, :serial_id,
+		(:id, :task_number, :sales_order_id, :sales_order_line_item_id, :product_id, :lot_id, :serial_id,
 		 :location_id, :quantity_to_pick, :quantity_picked, :status,
 		 :assigned_to, :assigned_at, :completed_by, :completed_at,
 		 :short_pick_reason, :created_by, :created_date, :updated_date)
@@ -76,6 +76,7 @@ func (s *Store) Update(ctx context.Context, task picktaskbus.PickTask) error {
 	const q = `
 	UPDATE inventory.pick_tasks
 	SET
+		task_number               = :task_number,
 		sales_order_id            = :sales_order_id,
 		sales_order_line_item_id  = :sales_order_line_item_id,
 		product_id                = :product_id,
@@ -131,7 +132,7 @@ func (s *Store) Query(ctx context.Context, filter picktaskbus.QueryFilter, order
 
 	const q = `
 	SELECT
-		id, sales_order_id, sales_order_line_item_id, product_id, lot_id, serial_id,
+		id, task_number, sales_order_id, sales_order_line_item_id, product_id, lot_id, serial_id,
 		location_id, quantity_to_pick, quantity_picked, status,
 		assigned_to, assigned_at, completed_by, completed_at,
 		short_pick_reason, created_by, created_date, updated_date
@@ -197,7 +198,7 @@ func (s *Store) QueryByID(ctx context.Context, taskID uuid.UUID) (picktaskbus.Pi
 
 	const q = `
 	SELECT
-		id, sales_order_id, sales_order_line_item_id, product_id, lot_id, serial_id,
+		id, task_number, sales_order_id, sales_order_line_item_id, product_id, lot_id, serial_id,
 		location_id, quantity_to_pick, quantity_picked, status,
 		assigned_to, assigned_at, completed_by, completed_at,
 		short_pick_reason, created_by, created_date, updated_date

--- a/business/domain/inventory/picktaskbus/testutil.go
+++ b/business/domain/inventory/picktaskbus/testutil.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"time"
 
 	"github.com/google/uuid"
 )
@@ -12,8 +13,11 @@ import (
 func TestNewPickTasks(n int, salesOrderIDs, salesOrderLineItemIDs, productIDs, locationIDs, createdByIDs []uuid.UUID) []NewPickTask {
 	tasks := make([]NewPickTask, n)
 
+	today := time.Now().Format("060102")
 	for i := range n {
+		num := fmt.Sprintf("PICK-%s-%04d", today, i+1)
 		tasks[i] = NewPickTask{
+			TaskNumber:           &num,
 			SalesOrderID:         salesOrderIDs[i%len(salesOrderIDs)],
 			SalesOrderLineItemID: salesOrderLineItemIDs[i%len(salesOrderLineItemIDs)],
 			ProductID:            productIDs[i%len(productIDs)],

--- a/business/domain/inventory/serialnumberbus/serialnumberbus_test.go
+++ b/business/domain/inventory/serialnumberbus/serialnumberbus_test.go
@@ -187,12 +187,7 @@ func insertSeedData(busDomain dbtest.BusDomain) (unitest.SeedData, error) {
 		return unitest.SeedData{}, fmt.Errorf("seeding zones : %w", err)
 	}
 
-	zoneIDs := make([]uuid.UUID, len(zones))
-	for i, z := range zones {
-		zoneIDs[i] = z.ZoneID
-	}
-
-	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 25, warehouseIDs, zoneIDs, busDomain.InventoryLocation)
+	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 25, warehouseIDs, zones, busDomain.InventoryLocation)
 	if err != nil {
 		return unitest.SeedData{}, fmt.Errorf("seeding inventory locations : %w", err)
 	}

--- a/business/domain/inventory/transferorderbus/model.go
+++ b/business/domain/inventory/transferorderbus/model.go
@@ -13,6 +13,7 @@ import (
 
 type TransferOrder struct {
 	TransferID      uuid.UUID  `json:"transfer_id"` // TODO: these should be id
+	TransferNumber  *string    `json:"transfer_number,omitempty"`
 	ProductID       uuid.UUID  `json:"product_id"`
 	FromLocationID  uuid.UUID  `json:"from_location_id"`
 	ToLocationID    uuid.UUID  `json:"to_location_id"`
@@ -33,6 +34,7 @@ type TransferOrder struct {
 }
 
 type NewTransferOrder struct {
+	TransferNumber *string    `json:"transfer_number,omitempty"`
 	ProductID      uuid.UUID  `json:"product_id"`
 	FromLocationID uuid.UUID  `json:"from_location_id"`
 	ToLocationID   uuid.UUID  `json:"to_location_id"`
@@ -44,6 +46,7 @@ type NewTransferOrder struct {
 }
 
 type UpdateTransferOrder struct {
+	TransferNumber  *string    `json:"transfer_number,omitempty"`
 	ProductID       *uuid.UUID `json:"product_id,omitempty"`
 	FromLocationID  *uuid.UUID `json:"from_location_id,omitempty"`
 	ToLocationID    *uuid.UUID `json:"to_location_id,omitempty"`

--- a/business/domain/inventory/transferorderbus/stores/transferorderdb/model.go
+++ b/business/domain/inventory/transferorderbus/stores/transferorderdb/model.go
@@ -9,8 +9,9 @@ import (
 )
 
 type transferOrder struct {
-	TransferID      uuid.UUID     `db:"id"`
-	ProductID       uuid.UUID     `db:"product_id"`
+	TransferID      uuid.UUID      `db:"id"`
+	TransferNumber  sql.NullString `db:"transfer_number"`
+	ProductID       uuid.UUID      `db:"product_id"`
 	FromLocationID  uuid.UUID     `db:"from_location_id"`
 	ToLocationID    uuid.UUID     `db:"to_location_id"`
 	RequestedByID   uuid.UUID     `db:"requested_by"`
@@ -30,8 +31,15 @@ type transferOrder struct {
 }
 
 func toBusTransferOrder(db transferOrder) transferorderbus.TransferOrder {
+	var transferNumber *string
+	if db.TransferNumber.Valid {
+		s := db.TransferNumber.String
+		transferNumber = &s
+	}
+
 	to := transferorderbus.TransferOrder{
 		TransferID:     db.TransferID,
+		TransferNumber: transferNumber,
 		ProductID:      db.ProductID,
 		FromLocationID: db.FromLocationID,
 		ToLocationID:   db.ToLocationID,
@@ -85,8 +93,14 @@ func toBusTransferOrders(dbs []transferOrder) []transferorderbus.TransferOrder {
 }
 
 func toDBTransferOrder(bus transferorderbus.TransferOrder) transferOrder {
+	var transferNumber sql.NullString
+	if bus.TransferNumber != nil {
+		transferNumber = sql.NullString{String: *bus.TransferNumber, Valid: true}
+	}
+
 	db := transferOrder{
 		TransferID:     bus.TransferID,
+		TransferNumber: transferNumber,
 		ProductID:      bus.ProductID,
 		FromLocationID: bus.FromLocationID,
 		ToLocationID:   bus.ToLocationID,

--- a/business/domain/inventory/transferorderbus/stores/transferorderdb/transferorderdb.go
+++ b/business/domain/inventory/transferorderbus/stores/transferorderdb/transferorderdb.go
@@ -42,12 +42,12 @@ func (s *Store) NewWithTx(tx sqldb.CommitRollbacker) (transferorderbus.Storer, e
 func (s *Store) Create(ctx context.Context, transferOrder transferorderbus.TransferOrder) error {
 	const q = `
 	INSERT INTO inventory.transfer_orders (
-	    id, product_id, from_location_id, to_location_id, requested_by,
+	    id, transfer_number, product_id, from_location_id, to_location_id, requested_by,
 		approved_by, rejected_by_id, approval_reason, rejection_reason,
 		claimed_by, claimed_at, completed_by, completed_at,
 		quantity, status, transfer_date, created_date, updated_date
     ) VALUES (
-        :id, :product_id, :from_location_id, :to_location_id, :requested_by,
+        :id, :transfer_number, :product_id, :from_location_id, :to_location_id, :requested_by,
         :approved_by, :rejected_by_id, :approval_reason, :rejection_reason,
         :claimed_by, :claimed_at, :completed_by, :completed_at,
         :quantity, :status, :transfer_date, :created_date, :updated_date
@@ -73,6 +73,7 @@ func (s *Store) Update(ctx context.Context, transferOrder transferorderbus.Trans
     UPDATE
         inventory.transfer_orders
     SET
+        transfer_number = :transfer_number,
         product_id = :product_id,
 		from_location_id = :from_location_id,
 		to_location_id = :to_location_id,
@@ -127,7 +128,7 @@ func (s *Store) Query(ctx context.Context, filter transferorderbus.QueryFilter, 
 
 	const q = `
 	SELECT
-		id, product_id, from_location_id, to_location_id, requested_by, approved_by,
+		id, transfer_number, product_id, from_location_id, to_location_id, requested_by, approved_by,
 		rejected_by_id, approval_reason, rejection_reason,
 		claimed_by, claimed_at, completed_by, completed_at,
 		quantity, status, transfer_date, created_date, updated_date
@@ -183,7 +184,7 @@ func (s *Store) QueryByID(ctx context.Context, transferOrderID uuid.UUID) (trans
 
 	const q = `
     SELECT
-        id, product_id, from_location_id, to_location_id, requested_by, approved_by,
+        id, transfer_number, product_id, from_location_id, to_location_id, requested_by, approved_by,
         rejected_by_id, approval_reason, rejection_reason,
         claimed_by, claimed_at, completed_by, completed_at,
         quantity, status, transfer_date, created_date, updated_date

--- a/business/domain/inventory/transferorderbus/testutil.go
+++ b/business/domain/inventory/transferorderbus/testutil.go
@@ -16,10 +16,13 @@ func TestNewTransferOrders(n int, productIDs, fromLocationIDs, toLocationIDs, re
 	// Status distribution: ~40% pending, ~40% approved, ~20% completed
 	transferStatuses := []string{StatusPending, StatusPending, StatusApproved, StatusApproved, StatusCompleted}
 
+	today := time.Now().Format("060102")
 	idx := rand.Intn(10000)
 	for i := range n {
 		idx++
+		num := fmt.Sprintf("XFER-%s-%04d", today, i+1)
 		newTransferOrders[i] = NewTransferOrder{
+			TransferNumber: &num,
 			ProductID:      productIDs[idx%len(productIDs)],
 			FromLocationID: fromLocationIDs[idx%len(fromLocationIDs)],
 			ToLocationID:   toLocationIDs[idx%len(toLocationIDs)],

--- a/business/domain/inventory/transferorderbus/transferorderbus.go
+++ b/business/domain/inventory/transferorderbus/transferorderbus.go
@@ -86,6 +86,7 @@ func (b *Business) Create(ctx context.Context, nto NewTransferOrder) (TransferOr
 
 	transferOrder := TransferOrder{
 		TransferID:     uuid.New(),
+		TransferNumber: nto.TransferNumber,
 		ProductID:      nto.ProductID,
 		FromLocationID: nto.FromLocationID,
 		ToLocationID:   nto.ToLocationID,
@@ -117,6 +118,9 @@ func (b *Business) Update(ctx context.Context, to TransferOrder, ut UpdateTransf
 
 	before := to
 
+	if ut.TransferNumber != nil {
+		to.TransferNumber = ut.TransferNumber
+	}
 	if ut.ProductID != nil {
 		to.ProductID = *ut.ProductID
 	}

--- a/business/domain/inventory/transferorderbus/transferorderbus_test.go
+++ b/business/domain/inventory/transferorderbus/transferorderbus_test.go
@@ -284,6 +284,7 @@ func update(busDomain dbtest.BusDomain, sd unitest.SeedData) []unitest.Table {
 		Name: "update",
 		ExpResp: transferorderbus.TransferOrder{
 			TransferID:     sd.TransferOrders[0].TransferID,
+			TransferNumber: sd.TransferOrders[0].TransferNumber,
 			ProductID:      sd.Products[0].ProductID,
 			FromLocationID: sd.InventoryLocations[0].LocationID,
 			ToLocationID:   sd.InventoryLocations[3].LocationID,

--- a/business/domain/inventory/transferorderbus/transferorderbus_test.go
+++ b/business/domain/inventory/transferorderbus/transferorderbus_test.go
@@ -174,12 +174,7 @@ func insertSeedData(busDomain dbtest.BusDomain) (unitest.SeedData, error) {
 		return unitest.SeedData{}, fmt.Errorf("seeding zones : %w", err)
 	}
 
-	zoneIDs := make([]uuid.UUID, len(zones))
-	for i, z := range zones {
-		zoneIDs[i] = z.ZoneID
-	}
-
-	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 25, warehouseIDs, zoneIDs, busDomain.InventoryLocation)
+	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 25, warehouseIDs, zones, busDomain.InventoryLocation)
 	if err != nil {
 		return unitest.SeedData{}, fmt.Errorf("seeding inventory locations : %w", err)
 	}

--- a/business/domain/inventory/zonebus/model.go
+++ b/business/domain/inventory/zonebus/model.go
@@ -15,6 +15,7 @@ type Zone struct {
 	ZoneID      uuid.UUID `json:"zone_id"`
 	WarehouseID uuid.UUID `json:"warehouse_id"`
 	Name        string    `json:"name"`
+	ZoneCode    *string   `json:"zone_code"`
 	Description string    `json:"description"`
 	Stage       *Stage    `json:"stage"`
 	CreatedDate time.Time `json:"created_date"`
@@ -24,6 +25,7 @@ type Zone struct {
 type NewZone struct {
 	WarehouseID uuid.UUID `json:"warehouse_id"`
 	Name        string    `json:"name"`
+	ZoneCode    *string   `json:"zone_code"`
 	Description string    `json:"description"`
 	Stage       *Stage    `json:"stage"`
 }
@@ -31,6 +33,7 @@ type NewZone struct {
 type UpdateZone struct {
 	WarehouseID *uuid.UUID `json:"warehouse_id,omitempty"`
 	Name        *string    `json:"name,omitempty"`
+	ZoneCode    *string    `json:"zone_code,omitempty"`
 	Description *string    `json:"description,omitempty"`
 	Stage       *Stage     `json:"stage,omitempty"`
 }

--- a/business/domain/inventory/zonebus/stores/zonedb/model.go
+++ b/business/domain/inventory/zonebus/stores/zonedb/model.go
@@ -12,6 +12,7 @@ type zone struct {
 	ZoneID      uuid.UUID      `db:"id"`
 	WarehouseID uuid.UUID      `db:"warehouse_id"`
 	Name        string         `db:"name"`
+	ZoneCode    sql.NullString `db:"zone_code"`
 	Description sql.NullString `db:"description"`
 	Stage       sql.NullString `db:"stage"`
 	CreatedDate time.Time      `db:"created_date"`
@@ -25,6 +26,9 @@ func toDBZone(bus zonebus.Zone) zone {
 		Name:        bus.Name,
 		CreatedDate: bus.CreatedDate.UTC(),
 		UpdatedDate: bus.UpdatedDate.UTC(),
+	}
+	if bus.ZoneCode != nil {
+		dest.ZoneCode = sql.NullString{String: *bus.ZoneCode, Valid: true}
 	}
 	if bus.Description != "" {
 		dest.Description = sql.NullString{String: bus.Description, Valid: true}
@@ -42,6 +46,10 @@ func toBusZone(db zone) zonebus.Zone {
 		Name:        db.Name,
 		CreatedDate: db.CreatedDate.Local(),
 		UpdatedDate: db.UpdatedDate.Local(),
+	}
+	if db.ZoneCode.Valid {
+		c := db.ZoneCode.String
+		dest.ZoneCode = &c
 	}
 	if db.Description.Valid {
 		dest.Description = db.Description.String

--- a/business/domain/inventory/zonebus/stores/zonedb/zonedb.go
+++ b/business/domain/inventory/zonebus/stores/zonedb/zonedb.go
@@ -48,9 +48,9 @@ func (s *Store) NewWithTx(tx sqldb.CommitRollbacker) (zonebus.Storer, error) {
 func (s *Store) Create(ctx context.Context, zone zonebus.Zone) error {
 	const q = `
 	INSERT INTO inventory.zones (
-		id, warehouse_id, name, description, stage, created_date, updated_date
+		id, warehouse_id, name, zone_code, description, stage, created_date, updated_date
 	) VALUES (
-		:id, :warehouse_id, :name, :description, :stage, :created_date, :updated_date
+		:id, :warehouse_id, :name, :zone_code, :description, :stage, :created_date, :updated_date
     )
 	`
 
@@ -75,6 +75,7 @@ func (s *Store) Update(ctx context.Context, zone zonebus.Zone) error {
         id = :id,
 		warehouse_id = :warehouse_id,
 		name = :name,
+		zone_code = :zone_code,
 		description = :description,
 		stage = :stage,
 		updated_date = :updated_date
@@ -117,7 +118,7 @@ func (s *Store) Query(ctx context.Context, filter zonebus.QueryFilter, orderBy o
 
 	const q = `
 	SELECT
-	    id, warehouse_id, name, description, stage, created_date, updated_date
+	    id, warehouse_id, name, zone_code, description, stage, created_date, updated_date
 	FROM
 		inventory.zones
 		`
@@ -173,7 +174,7 @@ func (s *Store) QueryByID(ctx context.Context, zoneID uuid.UUID) (zonebus.Zone, 
 
 	const q = `
 	SELECT
-	    id, warehouse_id, name, description, stage, created_date, updated_date
+	    id, warehouse_id, name, zone_code, description, stage, created_date, updated_date
 	FROM
 		inventory.zones
 	WHERE

--- a/business/domain/inventory/zonebus/testutil.go
+++ b/business/domain/inventory/zonebus/testutil.go
@@ -9,15 +9,25 @@ import (
 	"github.com/google/uuid"
 )
 
+// zoneCodeCycle is the sequence of 3-letter codes assigned to seed zones.
+// Matches Phase 1 physical warehouse layout (spec §3.3). Index i in the
+// 12-zone seed slice receives zoneCodeCycle[i % len(zoneCodeCycle)].
+var zoneCodeCycle = []string{
+	"RCV", "QA", "STG", "PCK", "PKG", "SHP",
+	"STG", "STG", "PCK", "PKG", "RCV", "STG",
+}
+
 func TestNewZone(n int, warehouseIDs []uuid.UUID) []NewZone {
 	newZones := make([]NewZone, n)
 
 	idx := rand.Intn(10000)
 	for i := 0; i < n; i++ {
 		idx++
+		code := zoneCodeCycle[i%len(zoneCodeCycle)]
 		newZones[i] = NewZone{
 			WarehouseID: warehouseIDs[idx%len(warehouseIDs)],
 			Name:        fmt.Sprintf("Name %d", idx),
+			ZoneCode:    &code,
 			Description: fmt.Sprintf("Description %d", idx),
 		}
 	}

--- a/business/domain/inventory/zonebus/zonebus.go
+++ b/business/domain/inventory/zonebus/zonebus.go
@@ -75,6 +75,7 @@ func (b *Business) Create(ctx context.Context, nz NewZone) (Zone, error) {
 		ZoneID:      uuid.New(),
 		WarehouseID: nz.WarehouseID,
 		Name:        nz.Name,
+		ZoneCode:    nz.ZoneCode,
 		Description: nz.Description,
 		Stage:       nz.Stage,
 		CreatedDate: now,
@@ -103,6 +104,9 @@ func (b *Business) Update(ctx context.Context, zone Zone, u UpdateZone) (Zone, e
 
 	if u.Name != nil {
 		zone.Name = *u.Name
+	}
+	if u.ZoneCode != nil {
+		zone.ZoneCode = u.ZoneCode
 	}
 	if u.Description != nil {
 		zone.Description = *u.Description

--- a/business/domain/inventory/zonebus/zonebus_test.go
+++ b/business/domain/inventory/zonebus/zonebus_test.go
@@ -105,6 +105,38 @@ func insertSeedData(busDomain dbtest.BusDomain) (unitest.SeedData, error) {
 
 }
 
+func Test_Zones_ZoneCode_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	db := dbtest.NewDatabase(t, "Test_Zones_ZoneCode_RoundTrip")
+	ctx := context.Background()
+
+	sd, err := insertSeedData(db.BusDomain)
+	if err != nil {
+		t.Fatalf("Seeding error: %s", err)
+	}
+
+	code := "RCV"
+	zone, err := db.BusDomain.Zones.Create(ctx, zonebus.NewZone{
+		WarehouseID: sd.Warehouses[0].ID,
+		Name:        "round-trip test",
+		ZoneCode:    &code,
+		Description: "test",
+	})
+	if err != nil {
+		t.Fatalf("Create: %s", err)
+	}
+
+	fetched, err := db.BusDomain.Zones.QueryByID(ctx, zone.ZoneID)
+	if err != nil {
+		t.Fatalf("QueryByID: %s", err)
+	}
+
+	if fetched.ZoneCode == nil || *fetched.ZoneCode != "RCV" {
+		t.Fatalf("expected ZoneCode=RCV, got %v", fetched.ZoneCode)
+	}
+}
+
 func query(busDomain dbtest.BusDomain, sd unitest.SeedData) []unitest.Table {
 	return []unitest.Table{
 		{
@@ -182,6 +214,7 @@ func update(busDomain dbtest.BusDomain, sd unitest.SeedData) []unitest.Table {
 			ExpResp: zonebus.Zone{
 				ZoneID:      sd.Zones[0].ZoneID,
 				Name:        "Updated Zone",
+				ZoneCode:    sd.Zones[0].ZoneCode,
 				Description: "an updated zone",
 				WarehouseID: sd.Warehouses[0].ID,
 				CreatedDate: sd.Zones[0].CreatedDate,

--- a/business/sdk/dbtest/seed_inventory.go
+++ b/business/sdk/dbtest/seed_inventory.go
@@ -64,12 +64,7 @@ func seedInventory(ctx context.Context, busDomain BusDomain, foundation Foundati
 		return InventorySeed{}, fmt.Errorf("seeding zones : %w", err)
 	}
 
-	zoneIDs := make([]uuid.UUID, len(zones))
-	for i, z := range zones {
-		zoneIDs[i] = z.ZoneID
-	}
-
-	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 25, warehouseIDs, zoneIDs, busDomain.InventoryLocation)
+	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 25, warehouseIDs, zones, busDomain.InventoryLocation)
 	if err != nil {
 		return InventorySeed{}, fmt.Errorf("seeding inventory locations : %w", err)
 	}

--- a/business/sdk/migrate/sql/migrate.sql
+++ b/business/sdk/migrate/sql/migrate.sql
@@ -2450,3 +2450,8 @@ CREATE INDEX idx_label_catalog_type ON inventory.label_catalog(type);
 -- Description: Phase 0c — add nullable zone_code to inventory.zones for 3-letter human-readable identifier.
 ALTER TABLE inventory.zones
     ADD COLUMN zone_code VARCHAR(16) NULL;
+
+-- Version: 2.31
+-- Description: Phase 0c — add nullable task_number to inventory.pick_tasks for human-readable pick task identifier (PICK-YYMMDD-serial).
+ALTER TABLE inventory.pick_tasks
+    ADD COLUMN task_number VARCHAR(32) NULL;

--- a/business/sdk/migrate/sql/migrate.sql
+++ b/business/sdk/migrate/sql/migrate.sql
@@ -2445,3 +2445,8 @@ CREATE TABLE inventory.label_catalog (
     created_date  TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 CREATE INDEX idx_label_catalog_type ON inventory.label_catalog(type);
+
+-- Version: 2.30
+-- Description: Phase 0c — add nullable zone_code to inventory.zones for 3-letter human-readable identifier.
+ALTER TABLE inventory.zones
+    ADD COLUMN zone_code VARCHAR(16) NULL;

--- a/business/sdk/migrate/sql/migrate.sql
+++ b/business/sdk/migrate/sql/migrate.sql
@@ -2460,3 +2460,8 @@ ALTER TABLE inventory.pick_tasks
 -- Description: Phase 0c — add nullable transfer_number to inventory.transfer_orders for human-readable transfer identifier (XFER-YYMMDD-serial).
 ALTER TABLE inventory.transfer_orders
     ADD COLUMN transfer_number VARCHAR(32) NULL;
+
+-- Version: 2.33
+-- Description: Phase 0c — add nullable item_code to inventory.cycle_count_items for human-readable cycle-count item identifier (CC-session_serial-item_serial).
+ALTER TABLE inventory.cycle_count_items
+    ADD COLUMN item_code VARCHAR(32) NULL;

--- a/business/sdk/migrate/sql/migrate.sql
+++ b/business/sdk/migrate/sql/migrate.sql
@@ -2455,3 +2455,8 @@ ALTER TABLE inventory.zones
 -- Description: Phase 0c — add nullable task_number to inventory.pick_tasks for human-readable pick task identifier (PICK-YYMMDD-serial).
 ALTER TABLE inventory.pick_tasks
     ADD COLUMN task_number VARCHAR(32) NULL;
+
+-- Version: 2.32
+-- Description: Phase 0c — add nullable transfer_number to inventory.transfer_orders for human-readable transfer identifier (XFER-YYMMDD-serial).
+ALTER TABLE inventory.transfer_orders
+    ADD COLUMN transfer_number VARCHAR(32) NULL;

--- a/business/sdk/tablebuilder/tablebuilder_test.go
+++ b/business/sdk/tablebuilder/tablebuilder_test.go
@@ -1139,12 +1139,7 @@ func insertSeedData(busDomain dbtest.BusDomain, configStore *tablebuilder.Config
 		return unitest.SeedData{}, fmt.Errorf("seeding zones : %w", err)
 	}
 
-	zoneIDs := make([]uuid.UUID, len(zones))
-	for i, z := range zones {
-		zoneIDs[i] = z.ZoneID
-	}
-
-	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 25, warehouseIDs, zoneIDs, busDomain.InventoryLocation)
+	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 25, warehouseIDs, zones, busDomain.InventoryLocation)
 	if err != nil {
 		return unitest.SeedData{}, fmt.Errorf("seeding inventory locations : %w", err)
 	}

--- a/business/sdk/workflow/workflowactions/inventory/allocate_test.go
+++ b/business/sdk/workflow/workflowactions/inventory/allocate_test.go
@@ -189,13 +189,8 @@ func insertAllocateSeedData(busDomain dbtest.BusDomain) (allocateSeedData, error
 		return allocateSeedData{}, fmt.Errorf("seeding zones : %w", err)
 	}
 
-	zoneIDs := make([]uuid.UUID, len(zones))
-	for i, z := range zones {
-		zoneIDs[i] = z.ZoneID
-	}
-
 	// Seed inventory locations
-	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 10, warehouseIDs, zoneIDs, busDomain.InventoryLocation)
+	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 10, warehouseIDs, zones, busDomain.InventoryLocation)
 	if err != nil {
 		return allocateSeedData{}, fmt.Errorf("seeding inventory locations : %w", err)
 	}

--- a/business/sdk/workflow/workflowactions/inventory/approve_adjustment_test.go
+++ b/business/sdk/workflow/workflowactions/inventory/approve_adjustment_test.go
@@ -169,12 +169,7 @@ func insertAdjustmentSeedData(busDomain dbtest.BusDomain) (adjustmentSeedData, e
 		return adjustmentSeedData{}, fmt.Errorf("seeding zones: %w", err)
 	}
 
-	zoneIDs := make([]uuid.UUID, len(zones))
-	for i, z := range zones {
-		zoneIDs[i] = z.ZoneID
-	}
-
-	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 5, warehouseIDs, zoneIDs, busDomain.InventoryLocation)
+	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 5, warehouseIDs, zones, busDomain.InventoryLocation)
 	if err != nil {
 		return adjustmentSeedData{}, fmt.Errorf("seeding inventory locations: %w", err)
 	}

--- a/business/sdk/workflow/workflowactions/inventory/approve_transfer_order_test.go
+++ b/business/sdk/workflow/workflowactions/inventory/approve_transfer_order_test.go
@@ -169,12 +169,7 @@ func insertTransferOrderSeedData(busDomain dbtest.BusDomain) (transferOrderSeedD
 		return transferOrderSeedData{}, fmt.Errorf("seeding zones: %w", err)
 	}
 
-	zoneIDs := make([]uuid.UUID, len(zones))
-	for i, z := range zones {
-		zoneIDs[i] = z.ZoneID
-	}
-
-	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 6, warehouseIDs, zoneIDs, busDomain.InventoryLocation)
+	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 6, warehouseIDs, zones, busDomain.InventoryLocation)
 	if err != nil {
 		return transferOrderSeedData{}, fmt.Errorf("seeding inventory locations: %w", err)
 	}

--- a/business/sdk/workflow/workflowactions/inventory/check_inventory_test.go
+++ b/business/sdk/workflow/workflowactions/inventory/check_inventory_test.go
@@ -166,12 +166,7 @@ func insertCheckInventorySeedData(busDomain dbtest.BusDomain) (checkInventorySee
 		return checkInventorySeedData{}, fmt.Errorf("seeding zones : %w", err)
 	}
 
-	zoneIDs := make([]uuid.UUID, len(zones))
-	for i, z := range zones {
-		zoneIDs[i] = z.ZoneID
-	}
-
-	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 10, warehouseIDs, zoneIDs, busDomain.InventoryLocation)
+	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 10, warehouseIDs, zones, busDomain.InventoryLocation)
 	if err != nil {
 		return checkInventorySeedData{}, fmt.Errorf("seeding inventory locations : %w", err)
 	}

--- a/business/sdk/workflow/workflowactions/inventory/check_reorder_point_test.go
+++ b/business/sdk/workflow/workflowactions/inventory/check_reorder_point_test.go
@@ -166,12 +166,7 @@ func insertCheckReorderPointSeedData(busDomain dbtest.BusDomain) (checkReorderPo
 		return checkReorderPointSeedData{}, fmt.Errorf("seeding zones : %w", err)
 	}
 
-	zoneIDs := make([]uuid.UUID, len(zones))
-	for i, z := range zones {
-		zoneIDs[i] = z.ZoneID
-	}
-
-	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 10, warehouseIDs, zoneIDs, busDomain.InventoryLocation)
+	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 10, warehouseIDs, zones, busDomain.InventoryLocation)
 	if err != nil {
 		return checkReorderPointSeedData{}, fmt.Errorf("seeding inventory locations : %w", err)
 	}

--- a/business/sdk/workflow/workflowactions/inventory/commit_allocation_test.go
+++ b/business/sdk/workflow/workflowactions/inventory/commit_allocation_test.go
@@ -167,12 +167,7 @@ func insertCommitAllocationSeedData(busDomain dbtest.BusDomain) (commitAllocatio
 		return commitAllocationSeedData{}, fmt.Errorf("seeding zones : %w", err)
 	}
 
-	zoneIDs := make([]uuid.UUID, len(zones))
-	for i, z := range zones {
-		zoneIDs[i] = z.ZoneID
-	}
-
-	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 10, warehouseIDs, zoneIDs, busDomain.InventoryLocation)
+	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 10, warehouseIDs, zones, busDomain.InventoryLocation)
 	if err != nil {
 		return commitAllocationSeedData{}, fmt.Errorf("seeding inventory locations : %w", err)
 	}

--- a/business/sdk/workflow/workflowactions/inventory/createputawaytask_test.go
+++ b/business/sdk/workflow/workflowactions/inventory/createputawaytask_test.go
@@ -175,12 +175,7 @@ func insertCreatePutAwayTaskSeedData(busDomain dbtest.BusDomain) (createPutAwayT
 	if err != nil {
 		return createPutAwayTaskSeedData{}, fmt.Errorf("seeding zones: %w", err)
 	}
-	zoneIDs := make([]uuid.UUID, len(zones))
-	for i, z := range zones {
-		zoneIDs[i] = z.ZoneID
-	}
-
-	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 5, warehouseIDs, zoneIDs, busDomain.InventoryLocation)
+	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 5, warehouseIDs, zones, busDomain.InventoryLocation)
 	if err != nil {
 		return createPutAwayTaskSeedData{}, fmt.Errorf("seeding inventory locations: %w", err)
 	}

--- a/business/sdk/workflow/workflowactions/inventory/receive_test.go
+++ b/business/sdk/workflow/workflowactions/inventory/receive_test.go
@@ -178,12 +178,7 @@ func insertReceiveSeedData(busDomain dbtest.BusDomain) (receiveSeedData, error) 
 		return receiveSeedData{}, fmt.Errorf("seeding zones: %w", err)
 	}
 
-	zoneIDs := make([]uuid.UUID, len(zones))
-	for i, z := range zones {
-		zoneIDs[i] = z.ZoneID
-	}
-
-	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 10, warehouseIDs, zoneIDs, busDomain.InventoryLocation)
+	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 10, warehouseIDs, zones, busDomain.InventoryLocation)
 	if err != nil {
 		return receiveSeedData{}, fmt.Errorf("seeding inventory locations: %w", err)
 	}

--- a/business/sdk/workflow/workflowactions/inventory/release_reservation_test.go
+++ b/business/sdk/workflow/workflowactions/inventory/release_reservation_test.go
@@ -167,12 +167,7 @@ func insertReleaseReservationSeedData(busDomain dbtest.BusDomain) (releaseReserv
 		return releaseReservationSeedData{}, fmt.Errorf("seeding zones : %w", err)
 	}
 
-	zoneIDs := make([]uuid.UUID, len(zones))
-	for i, z := range zones {
-		zoneIDs[i] = z.ZoneID
-	}
-
-	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 10, warehouseIDs, zoneIDs, busDomain.InventoryLocation)
+	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 10, warehouseIDs, zones, busDomain.InventoryLocation)
 	if err != nil {
 		return releaseReservationSeedData{}, fmt.Errorf("seeding inventory locations : %w", err)
 	}

--- a/business/sdk/workflow/workflowactions/inventory/reserve_inventory_test.go
+++ b/business/sdk/workflow/workflowactions/inventory/reserve_inventory_test.go
@@ -168,12 +168,7 @@ func insertReserveInventorySeedData(busDomain dbtest.BusDomain) (reserveInventor
 		return reserveInventorySeedData{}, fmt.Errorf("seeding zones : %w", err)
 	}
 
-	zoneIDs := make([]uuid.UUID, len(zones))
-	for i, z := range zones {
-		zoneIDs[i] = z.ZoneID
-	}
-
-	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 10, warehouseIDs, zoneIDs, busDomain.InventoryLocation)
+	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 10, warehouseIDs, zones, busDomain.InventoryLocation)
 	if err != nil {
 		return reserveInventorySeedData{}, fmt.Errorf("seeding inventory locations : %w", err)
 	}


### PR DESCRIPTION
## Summary

Phase 0c adds/backfills human-readable identifier columns needed by Phase 1 physical-warehouse testing (spec §3.7):

- `inventory.zones.zone_code` (new, nullable `VARCHAR(16)`, 3-letter Phase 1 code — seeder cycles `RCV,QA,STG,PCK,PKG,SHP,STG,STG,PCK,PKG,RCV,STG` across the 12 seed zones)
- `inventory.inventory_locations.location_code` (existing column — backfill seed format from `A-01-02-03` to `{ZoneCode}-{Aisle}{Rack}{Shelf}{Bin}`, e.g. `STG-A010203`)
- `inventory.pick_tasks.task_number` (new, nullable `VARCHAR(32)`, `PICK-YYMMDD-NNNN` — e.g. `PICK-260416-0001`)
- `inventory.transfer_orders.transfer_number` (new, nullable `VARCHAR(32)`, `XFER-YYMMDD-NNNN`)
- `inventory.cycle_count_items.item_code` (new, nullable `VARCHAR(32)`, `CC-NNN-NNN`)

All four new columns are nullable with no uniqueness constraint and no index — NOT NULL + indexes land in a later phase once all writers populate the field. Pure-backend; no frontend changes.

Five migrations: `2.30` (zones.zone_code), `2.31` (pick_tasks.task_number), `2.32` (transfer_orders.transfer_number), `2.33` (cycle_count_items.item_code). `location_code` already existed (migration 2.04) so no new migration for that — just a seed-generator format change.

The 38-file shape of commit 2 (\`b75f0d58\`) is a signature change on \`TestSeedInventoryLocations\` (\`zoneIDs []uuid.UUID\` → \`zones []zonebus.Zone\`) to give the location seeder access to each zone's \`ZoneCode\` for the new format. Every caller lost 4 lines of \`zoneIDs\` boilerplate and gained one call-argument substitution — net −177 lines from that commit alone.

Five test \`ExpResp\` additions propagate seeded identifier values through unchanged-update cases — one per domain (standard 'stale expectation after intentional behavior change' per CLAUDE.md testing policy).

## Test plan

- [x] \`go build ./...\` exit 0
- [x] Scoped \`go test\` across all 5 touched domains (bus + api) — green
- [x] Broader caller-sweep packages (20 additional packages touched by the 0c.2 signature change) — green when run individually; parallel-run noise was servicetest-container interference, not regression
- [x] \`make reseed-frontend\` applies migrations 2.30–2.33 cleanly
- [x] Pre-merge \`kubectl exec sts/database -- psql\` spot-check — every new column populated with expected format (zone_code=\`RCV/QA/STG\`, location_code=\`STG-A010203\`-style, task_number=\`PICK-260416-0001\`, transfer_number=\`XFER-260416-0001\`, item_code=\`CC-001-001\`)
- [ ] Post-merge smoke spot-check on master: same five \`SELECT\` queries return populated identifiers

Planning context: \`docs/superpowers/specs/2026-04-14-floor-physical-warehouse-testing-design.md\` §3.7. Execution notes: \`docs/superpowers/plans/floor-physical-warehouse-testing/NOTES.md\` (2026-04-16 checkpoint entry has the full per-task verification log).

🤖 Generated with [Claude Code](https://claude.com/claude-code)