### PR TITLE
feat(scenarios): fixture resolver + /fixtures endpoint (phase 0d-followup)

### DIFF
--- a/api/cmd/services/ichor/tests/scenarios/scenarioapi/fixtures_test.go
+++ b/api/cmd/services/ichor/tests/scenarios/scenarioapi/fixtures_test.go
@@ -1,0 +1,100 @@
+package scenarioapi_test
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
+	"github.com/timmaaaz/ichor/api/sdk/http/apitest"
+	"github.com/timmaaaz/ichor/app/domain/scenarios/scenarioapp"
+	"github.com/timmaaaz/ichor/app/sdk/errs"
+)
+
+func fixtures200(sd apitest.SeedData) []apitest.Table {
+	scenarioWithFixtures := sd.Scenarios[0]
+	scenarioWithoutFixtures := sd.Scenarios[1]
+
+	return []apitest.Table{
+		{
+			Name:       "with-fixtures",
+			URL:        fmt.Sprintf("/v1/scenarios/%s/fixtures", scenarioWithFixtures.ID),
+			Token:      sd.Admins[0].Token,
+			Method:     http.MethodGet,
+			StatusCode: http.StatusOK,
+			GotResp:    &scenarioapp.ScenarioFixtures{},
+			ExpResp:    nil,
+			CmpFunc: func(got, _ any) string {
+				r := got.(*scenarioapp.ScenarioFixtures)
+				if r.ID != scenarioWithFixtures.ID.String() {
+					return fmt.Sprintf("got ID %s, want %s", r.ID, scenarioWithFixtures.ID)
+				}
+				if r.Name != scenarioWithFixtures.Name {
+					return fmt.Sprintf("got Name %q, want %q", r.Name, scenarioWithFixtures.Name)
+				}
+				po := r.FixturesByTable["procurement.purchase_orders"]
+				if len(po) != 2 {
+					return fmt.Sprintf("procurement.purchase_orders: got %d rows, want 2", len(po))
+				}
+				ii := r.FixturesByTable["inventory.inventory_items"]
+				if len(ii) != 1 {
+					return fmt.Sprintf("inventory.inventory_items: got %d rows, want 1", len(ii))
+				}
+				return ""
+			},
+		},
+		{
+			Name:       "no-fixtures",
+			URL:        fmt.Sprintf("/v1/scenarios/%s/fixtures", scenarioWithoutFixtures.ID),
+			Token:      sd.Admins[0].Token,
+			Method:     http.MethodGet,
+			StatusCode: http.StatusOK,
+			GotResp:    &scenarioapp.ScenarioFixtures{},
+			ExpResp:    nil,
+			CmpFunc: func(got, _ any) string {
+				r := got.(*scenarioapp.ScenarioFixtures)
+				if r.ID != scenarioWithoutFixtures.ID.String() {
+					return fmt.Sprintf("got ID %s, want %s", r.ID, scenarioWithoutFixtures.ID)
+				}
+				if len(r.FixturesByTable) != 0 {
+					return fmt.Sprintf("got %d tables, want 0", len(r.FixturesByTable))
+				}
+				return ""
+			},
+		},
+	}
+}
+
+func fixtures404(sd apitest.SeedData) []apitest.Table {
+	return []apitest.Table{
+		{
+			Name:       "unknown-scenario",
+			URL:        fmt.Sprintf("/v1/scenarios/%s/fixtures", uuid.NewString()),
+			Token:      sd.Admins[0].Token,
+			Method:     http.MethodGet,
+			StatusCode: http.StatusNotFound,
+			GotResp:    &errs.Error{},
+			ExpResp:    errs.Newf(errs.NotFound, "scenario not found"),
+			CmpFunc: func(got, exp any) string {
+				return cmp.Diff(got, exp)
+			},
+		},
+	}
+}
+
+func fixtures401(sd apitest.SeedData) []apitest.Table {
+	return []apitest.Table{
+		{
+			Name:       "non-admin-401",
+			URL:        fmt.Sprintf("/v1/scenarios/%s/fixtures", sd.Scenarios[0].ID),
+			Token:      sd.Users[0].Token,
+			Method:     http.MethodGet,
+			StatusCode: http.StatusUnauthorized,
+			GotResp:    &errs.Error{},
+			ExpResp:    errs.Newf(errs.Unauthenticated, "authorize: you are not authorized for that action, claims[[USER]] rule[rule_admin_only]: rego evaluation failed : bindings results[[{[true] map[x:false]}]] ok[true]"),
+			CmpFunc: func(got, exp any) string {
+				return cmp.Diff(got, exp)
+			},
+		},
+	}
+}

--- a/api/cmd/services/ichor/tests/scenarios/scenarioapi/load_test.go
+++ b/api/cmd/services/ichor/tests/scenarios/scenarioapi/load_test.go
@@ -1,0 +1,78 @@
+package scenarioapi_test
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
+	"github.com/timmaaaz/ichor/api/sdk/http/apitest"
+	"github.com/timmaaaz/ichor/app/sdk/errs"
+)
+
+// load204 verifies POST /v1/scenarios/{id}/load returns 204 on two shapes:
+//   - scenarios[1]: no fixtures — ApplyFixtures is a no-op, active pointer flips
+//   - scenarios[2]: one resolvable fixture — ApplyFixtures inserts it
+//
+// The sub-tests run sequentially (apitest.Table is executed in slice order)
+// so the first Load's scenario_id becomes the currentActive before the
+// second Load. DeleteScopedRows then removes scenarios[1]'s footprint
+// (empty anyway) and ApplyFixtures applies scenarios[2]'s one row.
+func load204(sd apitest.SeedData) []apitest.Table {
+	return []apitest.Table{
+		{
+			Name:       "load-empty-scenario",
+			URL:        fmt.Sprintf("/v1/scenarios/%s/load", sd.Scenarios[1].ID),
+			Token:      sd.Admins[0].Token,
+			Method:     http.MethodPost,
+			StatusCode: http.StatusNoContent,
+			GotResp:    nil,
+			ExpResp:    nil,
+			CmpFunc:    func(_, _ any) string { return "" },
+		},
+		{
+			Name:       "load-scenario-with-fixture",
+			URL:        fmt.Sprintf("/v1/scenarios/%s/load", sd.Scenarios[2].ID),
+			Token:      sd.Admins[0].Token,
+			Method:     http.MethodPost,
+			StatusCode: http.StatusNoContent,
+			GotResp:    nil,
+			ExpResp:    nil,
+			CmpFunc:    func(_, _ any) string { return "" },
+		},
+	}
+}
+
+func load404(sd apitest.SeedData) []apitest.Table {
+	return []apitest.Table{
+		{
+			Name:       "unknown-scenario",
+			URL:        fmt.Sprintf("/v1/scenarios/%s/load", uuid.NewString()),
+			Token:      sd.Admins[0].Token,
+			Method:     http.MethodPost,
+			StatusCode: http.StatusNotFound,
+			GotResp:    &errs.Error{},
+			ExpResp:    errs.Newf(errs.NotFound, "scenario not found"),
+			CmpFunc: func(got, exp any) string {
+				return cmp.Diff(got, exp)
+			},
+		},
+	}
+}
+
+func load401(sd apitest.SeedData) []apitest.Table {
+	return []apitest.Table{
+		{
+			Name:       "non-admin-401",
+			URL:        fmt.Sprintf("/v1/scenarios/%s/load", sd.Scenarios[1].ID),
+			Token:      sd.Users[0].Token,
+			Method:     http.MethodPost,
+			StatusCode: http.StatusUnauthorized,
+			GotResp:    &errs.Error{},
+			ExpResp:    errs.Newf(errs.Unauthenticated, "authorize: you are not authorized for that action, claims[[USER]] rule[rule_admin_only]: rego evaluation failed : bindings results[[{[true] map[x:false]}]] ok[true]"),
+			CmpFunc: func(got, exp any) string {
+				return cmp.Diff(got, exp)
+			},
+		},
+	}
+}

--- a/api/cmd/services/ichor/tests/scenarios/scenarioapi/main_test.go
+++ b/api/cmd/services/ichor/tests/scenarios/scenarioapi/main_test.go
@@ -26,4 +26,10 @@ func Test_Scenarios(t *testing.T) {
 	test.Run(t, fixtures200(sd), "fixtures-200")
 	test.Run(t, fixtures401(sd), "fixtures-401")
 	test.Run(t, fixtures404(sd), "fixtures-404")
+	// load-401/404 must run BEFORE load-204: load-204 flips the active
+	// pointer to scenarios[2], and load-401/404 don't mutate state, so
+	// running them first keeps their assumptions stable.
+	test.Run(t, load401(sd), "load-401")
+	test.Run(t, load404(sd), "load-404")
+	test.Run(t, load204(sd), "load-204")
 }

--- a/api/cmd/services/ichor/tests/scenarios/scenarioapi/main_test.go
+++ b/api/cmd/services/ichor/tests/scenarios/scenarioapi/main_test.go
@@ -23,4 +23,7 @@ func Test_Scenarios(t *testing.T) {
 	test.Run(t, queryByID404(sd), "query-by-id-404")
 	test.Run(t, activeNone(sd), "active-none")
 	test.Run(t, active401(sd), "active-401")
+	test.Run(t, fixtures200(sd), "fixtures-200")
+	test.Run(t, fixtures401(sd), "fixtures-401")
+	test.Run(t, fixtures404(sd), "fixtures-404")
 }

--- a/api/cmd/services/ichor/tests/scenarios/scenarioapi/seed_test.go
+++ b/api/cmd/services/ichor/tests/scenarios/scenarioapi/seed_test.go
@@ -2,7 +2,9 @@ package scenarioapi_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/timmaaaz/ichor/api/domain/http/scenarios/scenarioapi"
@@ -49,6 +51,38 @@ func insertSeedData(db *dbtest.Database, ath *auth.Auth) (apitest.SeedData, erro
 	scenarios, err := scenariobus.TestSeedScenarios(ctx, 3, busDomain.Scenario)
 	if err != nil {
 		return apitest.SeedData{}, fmt.Errorf("seeding scenarios: %w", err)
+	}
+
+	// Attach two fixtures to scenarios[0] across two target tables so the
+	// /fixtures endpoint has something to return AND the grouping-by-table
+	// assertion is meaningful.
+	fixtures := []scenariobus.ScenarioFixture{
+		{
+			ID:          uuid.New(),
+			ScenarioID:  scenarios[0].ID,
+			TargetTable: "procurement.purchase_orders",
+			PayloadJSON: mustJSON(map[string]any{"number": "PO-TEST-001"}),
+			CreatedDate: time.Now(),
+		},
+		{
+			ID:          uuid.New(),
+			ScenarioID:  scenarios[0].ID,
+			TargetTable: "procurement.purchase_orders",
+			PayloadJSON: mustJSON(map[string]any{"number": "PO-TEST-002"}),
+			CreatedDate: time.Now(),
+		},
+		{
+			ID:          uuid.New(),
+			ScenarioID:  scenarios[0].ID,
+			TargetTable: "inventory.inventory_items",
+			PayloadJSON: mustJSON(map[string]any{"quantity": 50}),
+			CreatedDate: time.Now(),
+		},
+	}
+	for _, f := range fixtures {
+		if err := busDomain.Scenario.SeedCreateFixture(ctx, f); err != nil {
+			return apitest.SeedData{}, fmt.Errorf("seeding fixture: %w", err)
+		}
 	}
 
 	roles, err := rolebus.TestSeedRoles(ctx, 2, busDomain.Role)
@@ -99,8 +133,17 @@ func insertSeedData(db *dbtest.Database, ath *auth.Auth) (apitest.SeedData, erro
 	}
 
 	return apitest.SeedData{
-		Admins:    []apitest.User{tu2},
-		Users:     []apitest.User{tu1},
-		Scenarios: scenarios,
+		Admins:           []apitest.User{tu2},
+		Users:            []apitest.User{tu1},
+		Scenarios:        scenarios,
+		ScenarioFixtures: fixtures,
 	}, nil
+}
+
+func mustJSON(v any) []byte {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return b
 }

--- a/api/cmd/services/ichor/tests/scenarios/scenarioapi/seed_test.go
+++ b/api/cmd/services/ichor/tests/scenarios/scenarioapi/seed_test.go
@@ -53,9 +53,12 @@ func insertSeedData(db *dbtest.Database, ath *auth.Auth) (apitest.SeedData, erro
 		return apitest.SeedData{}, fmt.Errorf("seeding scenarios: %w", err)
 	}
 
-	// Attach two fixtures to scenarios[0] across two target tables so the
-	// /fixtures endpoint has something to return AND the grouping-by-table
-	// assertion is meaningful.
+	// Attach fixtures across three scenarios to exercise different test paths:
+	//   - scenarios[0]: fake payloads for two target tables (/fixtures shape test)
+	//   - scenarios[1]: no fixtures (empty /fixtures + empty Load test)
+	//   - scenarios[2]: one pre-resolved sales.order_fulfillment_statuses row
+	//                   that can actually INSERT via ApplyFixtures (Load test)
+	fulfillmentRowID := uuid.New()
 	fixtures := []scenariobus.ScenarioFixture{
 		{
 			ID:          uuid.New(),
@@ -76,6 +79,21 @@ func insertSeedData(db *dbtest.Database, ath *auth.Auth) (apitest.SeedData, erro
 			ScenarioID:  scenarios[0].ID,
 			TargetTable: "inventory.inventory_items",
 			PayloadJSON: mustJSON(map[string]any{"quantity": 50}),
+			CreatedDate: time.Now(),
+		},
+		{
+			// Pre-resolved fixture usable by ApplyFixtures. name UNIQUE on
+			// the table, so pick a scenario-unique prefix so we don't
+			// collide with baseline (PENDING / PROCESSING / etc.).
+			ID:          uuid.New(),
+			ScenarioID:  scenarios[2].ID,
+			TargetTable: "sales.order_fulfillment_statuses",
+			PayloadJSON: mustJSON(map[string]any{
+				"id":          fulfillmentRowID.String(),
+				"name":        "SCEN-APITEST-STATUS",
+				"description": "load-test fixture row",
+				"scenario_id": scenarios[2].ID.String(),
+			}),
 			CreatedDate: time.Now(),
 		},
 	}

--- a/api/domain/http/scenarios/scenarioapi/route.go
+++ b/api/domain/http/scenarios/scenarioapi/route.go
@@ -45,6 +45,9 @@ func Routes(app *web.App, cfg Config) {
 	app.HandlerFunc(http.MethodGet, version, "/scenarios/{id}", a.queryByID, authen,
 		authorize(permissionsbus.Actions.Read))
 
+	app.HandlerFunc(http.MethodGet, version, "/scenarios/{id}/fixtures", a.fixtures, authen,
+		authorize(permissionsbus.Actions.Read))
+
 	app.HandlerFunc(http.MethodPost, version, "/scenarios", a.create, authen,
 		authorize(permissionsbus.Actions.Create))
 

--- a/api/domain/http/scenarios/scenarioapi/scenarioapi.go
+++ b/api/domain/http/scenarios/scenarioapi/scenarioapi.go
@@ -94,6 +94,20 @@ func (a *api) query(ctx context.Context, r *http.Request) web.Encoder {
 	return scenarios
 }
 
+// fixtures handles GET /v1/scenarios/{id}/fixtures.
+func (a *api) fixtures(ctx context.Context, r *http.Request) web.Encoder {
+	id, err := uuid.Parse(web.Param(r, "id"))
+	if err != nil {
+		return errs.New(errs.InvalidArgument, err)
+	}
+
+	s, err := a.scenarioapp.Fixtures(ctx, id)
+	if err != nil {
+		return errs.NewError(err)
+	}
+	return s
+}
+
 // active handles GET /v1/scenarios/active.
 func (a *api) active(ctx context.Context, r *http.Request) web.Encoder {
 	s, err := a.scenarioapp.Active(ctx)

--- a/api/sdk/http/apitest/model.go
+++ b/api/sdk/http/apitest/model.go
@@ -151,6 +151,7 @@ type SeedData struct {
 	Orders                      []ordersapp.Order
 	OrderLineItems              []orderlineitemsapp.OrderLineItem
 	Scenarios                   []scenariobus.Scenario
+	ScenarioFixtures            []scenariobus.ScenarioFixture
 	SimpleTableConfig           *tablebuilder.StoredConfig
 	ComplexTableConfig          *tablebuilder.StoredConfig
 	PageTableConfig             *tablebuilder.StoredConfig

--- a/app/domain/scenarios/scenarioapp/model.go
+++ b/app/domain/scenarios/scenarioapp/model.go
@@ -111,3 +111,50 @@ func toBusUpdateScenario(app UpdateScenario) scenariobus.UpdateScenario {
 		Description: app.Description,
 	}
 }
+
+// =============================================================================
+
+// ScenarioFixture is the API-facing shape of a single fixture row.
+// Payload is emitted as raw JSON so callers decode per target_table schema.
+type ScenarioFixture struct {
+	ID          string          `json:"id"`
+	TargetTable string          `json:"target_table"`
+	Payload     json.RawMessage `json:"payload"`
+	CreatedDate string          `json:"created_date"`
+}
+
+// ScenarioFixtures is the GET /v1/scenarios/{id}/fixtures response. Fixture
+// rows are grouped by their target_table so the frontend can reassemble the
+// tote → lot → product preview without re-walking the flat slice.
+type ScenarioFixtures struct {
+	ID              string                       `json:"id"`
+	Name            string                       `json:"name"`
+	FixturesByTable map[string][]ScenarioFixture `json:"fixtures_by_table"`
+}
+
+// Encode implements the web.Encoder interface.
+func (app ScenarioFixtures) Encode() ([]byte, string, error) {
+	data, err := json.Marshal(app)
+	return data, "application/json", err
+}
+
+func toAppScenarioFixtures(s scenariobus.Scenario, fixtures []scenariobus.ScenarioFixture) ScenarioFixtures {
+	byTable := make(map[string][]ScenarioFixture, 4)
+	for _, f := range fixtures {
+		payload := json.RawMessage(f.PayloadJSON)
+		if len(payload) == 0 {
+			payload = json.RawMessage("null")
+		}
+		byTable[f.TargetTable] = append(byTable[f.TargetTable], ScenarioFixture{
+			ID:          f.ID.String(),
+			TargetTable: f.TargetTable,
+			Payload:     payload,
+			CreatedDate: f.CreatedDate.Format(timeutil.FORMAT),
+		})
+	}
+	return ScenarioFixtures{
+		ID:              s.ID.String(),
+		Name:            s.Name,
+		FixturesByTable: byTable,
+	}
+}

--- a/app/domain/scenarios/scenarioapp/scenarioapp.go
+++ b/app/domain/scenarios/scenarioapp/scenarioapp.go
@@ -109,6 +109,25 @@ func (a *App) Query(ctx context.Context, qp QueryParams) (Scenarios, error) {
 	return toAppScenarios(scenarios), nil
 }
 
+// Fixtures returns all fixture rows for the given scenario grouped by target_table.
+// Returns HTTP 404 if the scenario does not exist.
+func (a *App) Fixtures(ctx context.Context, scenarioID uuid.UUID) (ScenarioFixtures, error) {
+	s, err := a.bus.QueryByID(ctx, scenarioID)
+	if err != nil {
+		if errors.Is(err, scenariobus.ErrNotFound) {
+			return ScenarioFixtures{}, errs.New(errs.NotFound, scenariobus.ErrNotFound)
+		}
+		return ScenarioFixtures{}, errs.Newf(errs.Internal, "querybyid: %s", err)
+	}
+
+	fixtures, err := a.bus.Fixtures(ctx, scenarioID)
+	if err != nil {
+		return ScenarioFixtures{}, errs.Newf(errs.Internal, "fixtures: %s", err)
+	}
+
+	return toAppScenarioFixtures(s, fixtures), nil
+}
+
 // Active returns the currently active scenario.
 // Returns HTTP 404 if no scenario is active.
 func (a *App) Active(ctx context.Context) (Scenario, error) {

--- a/business/domain/scenarios/scenariobus/scenariobus.go
+++ b/business/domain/scenarios/scenariobus/scenariobus.go
@@ -206,6 +206,22 @@ func (b *Business) Query(ctx context.Context, filter QueryFilter, orderBy order.
 	return scenarios, nil
 }
 
+// Fixtures returns all fixture rows for the given scenario, ordered by
+// target_table then created_date. Returns ErrNotFound if the scenario itself
+// does not exist; returns an empty slice (not an error) if the scenario has
+// no fixtures.
+func (b *Business) Fixtures(ctx context.Context, scenarioID uuid.UUID) ([]ScenarioFixture, error) {
+	if _, err := b.storer.QueryByID(ctx, scenarioID); err != nil {
+		return nil, fmt.Errorf("fixtures querybyid: %w", err)
+	}
+
+	fixtures, err := b.storer.QueryFixturesByScenario(ctx, scenarioID)
+	if err != nil {
+		return nil, fmt.Errorf("fixtures: %w", err)
+	}
+	return fixtures, nil
+}
+
 // Active returns the currently active scenario or ErrNotFound if none is set.
 func (b *Business) Active(ctx context.Context) (Scenario, error) {
 	activeID, err := b.storer.QueryActive(ctx)

--- a/business/sdk/dbtest/seed_scenarios.go
+++ b/business/sdk/dbtest/seed_scenarios.go
@@ -40,6 +40,8 @@ func seedScenarios(ctx context.Context, busDomain BusDomain) error {
 		return fmt.Errorf("yamlload.Load: %w", err)
 	}
 
+	lookups := newRefLookups(busDomain.Product, busDomain.InventoryLocation, busDomain.Label)
+
 	for _, s := range scenarios {
 		bus := scenariobus.Scenario{
 			ID:          s.ID,
@@ -65,7 +67,11 @@ func seedScenarios(ctx context.Context, busDomain BusDomain) error {
 				return fmt.Errorf("scenario %s: unknown state key %q (no schema.table mapping)", s.Name, tableSuffix)
 			}
 			for i, row := range s.State[tableSuffix] {
-				payload, err := yamlload.PayloadJSON(row)
+				resolved, err := resolveRefs(ctx, row, s.ID, lookups)
+				if err != nil {
+					return fmt.Errorf("scenario %s: resolve refs %s[%d]: %w", s.Name, targetTable, i, err)
+				}
+				payload, err := yamlload.PayloadJSON(resolved)
 				if err != nil {
 					return fmt.Errorf("scenario %s: payload marshal: %w", s.Name, err)
 				}

--- a/business/sdk/dbtest/seed_scenarios_refs.go
+++ b/business/sdk/dbtest/seed_scenarios_refs.go
@@ -1,0 +1,125 @@
+package dbtest
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	inventorylocationbus "github.com/timmaaaz/ichor/business/domain/inventory/inventorylocationbus"
+	"github.com/timmaaaz/ichor/business/domain/labels/labelbus"
+	"github.com/timmaaaz/ichor/business/domain/products/productbus"
+	"github.com/timmaaaz/ichor/business/sdk/order"
+	"github.com/timmaaaz/ichor/business/sdk/page"
+)
+
+// refResolver resolves a single stable human-readable code to a UUID.
+// Each ref suffix (product_ref, location_ref, tote_ref) has its own
+// resolver so the dispatch in resolveRefs can stay a flat switch.
+type refResolver func(ctx context.Context, value string) (uuid.UUID, error)
+
+// refLookups bundles the three resolver functions the seeder uses at
+// fixture-materialization time. Exposed as an interface (via fields, not
+// methods) so the unit test can pass fakes without touching a live DB.
+type refLookups struct {
+	productIDBySKU   refResolver
+	locationIDByCode refResolver
+	labelIDByCode    refResolver
+}
+
+// newRefLookups wires resolvers against real bus instances. Seeder path.
+func newRefLookups(prod *productbus.Business, loc *inventorylocationbus.Business, lbl *labelbus.Business) refLookups {
+	return refLookups{
+		productIDBySKU: func(ctx context.Context, sku string) (uuid.UUID, error) {
+			filter := productbus.QueryFilter{SKU: &sku}
+			orderBy := productbus.DefaultOrderBy
+			pg := page.MustParse("1", "1")
+			rows, err := prod.Query(ctx, filter, orderBy, pg)
+			if err != nil {
+				return uuid.Nil, fmt.Errorf("product query sku=%s: %w", sku, err)
+			}
+			if len(rows) == 0 {
+				return uuid.Nil, fmt.Errorf("product not found for sku=%s", sku)
+			}
+			return rows[0].ProductID, nil
+		},
+		locationIDByCode: func(ctx context.Context, code string) (uuid.UUID, error) {
+			filter := inventorylocationbus.QueryFilter{LocationCodeExact: &code}
+			orderBy := order.NewBy("location_code", order.ASC)
+			pg := page.MustParse("1", "1")
+			rows, err := loc.Query(ctx, filter, orderBy, pg)
+			if err != nil {
+				return uuid.Nil, fmt.Errorf("location query code=%s: %w", code, err)
+			}
+			if len(rows) == 0 {
+				return uuid.Nil, fmt.Errorf("location not found for code=%s", code)
+			}
+			return rows[0].LocationID, nil
+		},
+		labelIDByCode: func(ctx context.Context, code string) (uuid.UUID, error) {
+			lc, err := lbl.QueryByCode(ctx, code)
+			if err != nil {
+				return uuid.Nil, fmt.Errorf("label queryByCode=%s: %w", code, err)
+			}
+			return lc.ID, nil
+		},
+	}
+}
+
+// refKeySuffix identifies a key that needs ref→id resolution. Kept as a
+// constant set so unknown suffixes (e.g. warehouse_ref) fail loudly rather
+// than being silently passed through as strings into payload_json.
+var knownRefSuffixes = map[string]struct{}{
+	"product_ref":  {},
+	"location_ref": {},
+	"tote_ref":     {},
+}
+
+// resolveRefs rewrites a single state.yaml row in place:
+//   - replaces "<prefix>_ref" string values with "<prefix>_id" UUID values
+//     using the appropriate resolver
+//   - injects scenario_id if not already present
+//
+// Keys that don't end in "_ref" pass through untouched. Unknown "_ref" keys
+// (e.g. future "supplier_ref" before a resolver lands) fail-hard so silent
+// mis-seeding can't happen.
+func resolveRefs(ctx context.Context, row map[string]any, scenarioID uuid.UUID, lookups refLookups) (map[string]any, error) {
+	out := make(map[string]any, len(row)+1)
+	for k, v := range row {
+		if !strings.HasSuffix(k, "_ref") {
+			out[k] = v
+			continue
+		}
+		if _, ok := knownRefSuffixes[k]; !ok {
+			return nil, fmt.Errorf("unknown ref key %q (expected one of product_ref/location_ref/tote_ref)", k)
+		}
+		code, ok := v.(string)
+		if !ok {
+			return nil, fmt.Errorf("ref key %q must be a string, got %T", k, v)
+		}
+
+		var id uuid.UUID
+		var err error
+		var targetKey string
+		switch k {
+		case "product_ref":
+			targetKey = "product_id"
+			id, err = lookups.productIDBySKU(ctx, code)
+		case "location_ref":
+			targetKey = "location_id"
+			id, err = lookups.locationIDByCode(ctx, code)
+		case "tote_ref":
+			targetKey = "label_catalog_id"
+			id, err = lookups.labelIDByCode(ctx, code)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("resolve %s=%q: %w", k, code, err)
+		}
+		out[targetKey] = id.String()
+	}
+
+	if _, ok := out["scenario_id"]; !ok {
+		out["scenario_id"] = scenarioID.String()
+	}
+	return out, nil
+}

--- a/business/sdk/dbtest/seed_scenarios_refs_test.go
+++ b/business/sdk/dbtest/seed_scenarios_refs_test.go
@@ -1,0 +1,158 @@
+package dbtest
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func fixedLookups(t *testing.T) refLookups {
+	t.Helper()
+	productID := uuid.MustParse("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+	locationID := uuid.MustParse("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb")
+	labelID := uuid.MustParse("cccccccc-cccc-4ccc-8ccc-cccccccccccc")
+
+	return refLookups{
+		productIDBySKU: func(_ context.Context, sku string) (uuid.UUID, error) {
+			if sku != "SKU-0001" {
+				return uuid.Nil, errors.New("not found")
+			}
+			return productID, nil
+		},
+		locationIDByCode: func(_ context.Context, code string) (uuid.UUID, error) {
+			if code != "RCV-A010101" {
+				return uuid.Nil, errors.New("not found")
+			}
+			return locationID, nil
+		},
+		labelIDByCode: func(_ context.Context, code string) (uuid.UUID, error) {
+			if code != "TOTE-001" {
+				return uuid.Nil, errors.New("not found")
+			}
+			return labelID, nil
+		},
+	}
+}
+
+func TestResolveRefs(t *testing.T) {
+	t.Parallel()
+
+	scenarioID := uuid.MustParse("dddddddd-dddd-4ddd-8ddd-dddddddddddd")
+	lookups := fixedLookups(t)
+	ctx := context.Background()
+
+	tests := []struct {
+		name      string
+		in        map[string]any
+		expect    map[string]any
+		expectErr string
+	}{
+		{
+			name: "product_ref resolves to product_id, scenario_id injected",
+			in: map[string]any{
+				"quantity":    50,
+				"product_ref": "SKU-0001",
+			},
+			expect: map[string]any{
+				"quantity":    50,
+				"product_id":  "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+				"scenario_id": "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+			},
+		},
+		{
+			name: "three refs together",
+			in: map[string]any{
+				"product_ref":  "SKU-0001",
+				"location_ref": "RCV-A010101",
+				"tote_ref":     "TOTE-001",
+			},
+			expect: map[string]any{
+				"product_id":       "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+				"location_id":      "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+				"label_catalog_id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+				"scenario_id":      "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+			},
+		},
+		{
+			name: "existing scenario_id preserved (not overwritten)",
+			in: map[string]any{
+				"product_ref": "SKU-0001",
+				"scenario_id": "9999eeee-eeee-4eee-8eee-eeeeeeeeeeee",
+			},
+			expect: map[string]any{
+				"product_id":  "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+				"scenario_id": "9999eeee-eeee-4eee-8eee-eeeeeeeeeeee",
+			},
+		},
+		{
+			name: "already-resolved _id pass-through",
+			in: map[string]any{
+				"product_id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+				"quantity":   10,
+			},
+			expect: map[string]any{
+				"product_id":  "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+				"quantity":    10,
+				"scenario_id": "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+			},
+		},
+		{
+			name: "unknown _ref key errors",
+			in: map[string]any{
+				"supplier_ref": "Acme Inc",
+			},
+			expectErr: "unknown ref key",
+		},
+		{
+			name: "non-string ref value errors",
+			in: map[string]any{
+				"product_ref": 42,
+			},
+			expectErr: "must be a string",
+		},
+		{
+			name: "resolver failure propagates",
+			in: map[string]any{
+				"product_ref": "SKU-NONEXISTENT",
+			},
+			expectErr: "resolve product_ref",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := resolveRefs(ctx, tc.in, scenarioID, lookups)
+			if tc.expectErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil (out=%v)", tc.expectErr, got)
+				}
+				if !strings.Contains(err.Error(), tc.expectErr) {
+					t.Fatalf("error %q does not contain %q", err.Error(), tc.expectErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != len(tc.expect) {
+				t.Fatalf("key count mismatch: got %d %v, want %d %v", len(got), got, len(tc.expect), tc.expect)
+			}
+			for k, v := range tc.expect {
+				gv, ok := got[k]
+				if !ok {
+					t.Errorf("missing key %q in output", k)
+					continue
+				}
+				if gv != v {
+					t.Errorf("key %q: got %v (%T), want %v (%T)", k, gv, gv, v, v)
+				}
+			}
+		})
+	}
+}

--- a/deployments/scenarios/rush-receiving/state.yaml
+++ b/deployments/scenarios/rush-receiving/state.yaml
@@ -1,47 +1,20 @@
 # deployments/scenarios/rush-receiving/state.yaml
 #
-# Row blueprints keyed by target-table suffix. The Phase 1 seeder resolves
-# each suffix to a schema.table (e.g. "purchase_orders" -> procurement.purchase_orders),
-# JSON-marshals each row into scenario_fixtures.payload_json, and inserts
-# at Load time.
+# State intentionally empty. Phase 0d-followup-fixtures (2026-04-22) landed
+# a seed-time `_ref → _id` resolver in business/sdk/dbtest/seed_scenarios_refs.go
+# that supports three key suffixes:
 #
-# Column names below are illustrative — the actual procurement.purchase_orders
-# DDL (migrate.sql:1566-1624) requires order_number / purchase_order_status_id
-# (UUID FK) / supplier_id / delivery_warehouse_id / currency_id / requested_by
-# / created_by / updated_by + timestamps. Plan §0d.9 Step 3 explicitly starts
-# with this minimal shape and defers FK-correct column expansion to Phase 1.
+#   product_ref  → products.products.sku → product_id
+#   location_ref → inventory.inventory_locations.location_code → location_id
+#   tote_ref     → inventory.label_catalog.code → label_catalog_id
 #
-# IDs use hand-rolled UUIDv4-shaped hex for readability. A future refinement
-# switches to UUID v5 of "fixture:rush-receiving:<table>:<idx>" under the
-# deadbeef namespace (mirrors scenarios.yaml's UUID v5 determinism contract).
+# Realistic purchase_orders / inventory_items fixtures require additional
+# `_ref` types (supplier_ref, warehouse_ref, currency_ref, user_ref,
+# purchase_order_status_ref) that are not yet implemented. Phase 1 authors
+# those resolvers + the first real state.yaml rows using them.
+#
+# Until then, rush-receiving ships as a metadata-only scenario: the Load
+# endpoint still swaps the active pointer and deletes any prior active
+# scenario's scoped rows — it just has no new fixture rows to apply.
 
-purchase_orders:
-  - id: 11111111-1111-4111-8111-111111111001
-    number: PO-SCEN-RUSH-001
-    status: SENT
-    expected_arrival_date: "2026-04-21T09:00:00Z"
-    created_date: "2026-04-20T08:00:00Z"
-    updated_date: "2026-04-20T08:00:00Z"
-  - id: 11111111-1111-4111-8111-111111111002
-    number: PO-SCEN-RUSH-002
-    status: SENT
-    expected_arrival_date: "2026-04-21T10:00:00Z"
-    created_date: "2026-04-20T08:00:00Z"
-    updated_date: "2026-04-20T08:00:00Z"
-  - id: 11111111-1111-4111-8111-111111111003
-    number: PO-SCEN-RUSH-003
-    status: SENT
-    expected_arrival_date: "2026-04-21T11:00:00Z"
-    created_date: "2026-04-20T08:00:00Z"
-    updated_date: "2026-04-20T08:00:00Z"
-
-# One inventory_items row exercises the multi-table shape of State
-# (map[string][]map[string]any). Satisfies the plan's "1 PO + 1 inventory_item
-# that gets tagged" fallback condition even though we ship 3 POs.
-inventory_items:
-  - id: 22222222-2222-4222-8222-222222222001
-    product_ref: SKU-0001
-    location_ref: RCV-A010101
-    quantity: 50
-    created_date: "2026-04-20T08:00:00Z"
-    updated_date: "2026-04-20T08:00:00Z"
+{}

--- a/docs/arch/seeding.md
+++ b/docs/arch/seeding.md
@@ -487,6 +487,36 @@ symptom → fix:
 
 ---
 
+## ⚠ Scenario fixture `_ref → _id` resolver
+
+file: business/sdk/dbtest/seed_scenarios_refs.go
+
+state.yaml rows may use stable human-readable codes for three FK types.
+The seeder resolves them to UUIDs before writing to
+`inventory.scenario_fixtures.payload_json`, so `scenariodb.ApplyFixtures`
+stays table-agnostic and `jsonb_populate_record` receives real UUIDs
+on every typed column.
+
+| state.yaml key | Resolved via | Output key |
+|---|---|---|
+| `product_ref` | `productbus.Query{SKU}` | `product_id` |
+| `location_ref` | `inventorylocationbus.Query{LocationCodeExact}` | `location_id` |
+| `tote_ref` | `labelbus.QueryByCode` | `label_catalog_id` |
+
+Any key ending in `_ref` that is NOT one of the three above is a
+fail-hard error — prevents silent mis-seeding when new ref types are
+added to YAML before their resolvers land.
+
+`scenario_id` is also auto-injected when absent, so `DeleteScopedRows`
+can remove the fixture rows on the next Load.
+
+Further `_ref` types (e.g. `supplier_ref`, `warehouse_ref`, `currency_ref`,
+`user_ref`, `purchase_order_status_ref`) are expected to land alongside
+the first real scenario fixtures that need them. Add each new resolver
+as a field on `refLookups` and a case in `resolveRefs`'s switch.
+
+---
+
 ## ⚠ Adding a new domain to seeding
 
   business/sdk/dbtest/dbtest.go          (add bus field(s) to BusDomain struct + instantiate in newBusDomains)


### PR DESCRIPTION
## Summary

Unblocks Phase 0f (Vue scenarios admin UI) by fixing two backend gaps surfaced in Phase 0f S1's stop-protocol:

- **D — fixture resolver:** seed-time \`_ref → _id\` resolver in \`business/sdk/dbtest/seed_scenarios_refs.go\` rewrites state.yaml rows before \`PayloadJSON\` marshal so \`jsonb_populate_record\` receives real UUIDs on typed columns. Three ref types supported today: \`product_ref\`, \`location_ref\`, \`tote_ref\`. Unknown suffixes fail loudly.
- **F — bindings endpoint:** new \`GET /v1/scenarios/{id}/fixtures\` returns raw fixture rows grouped by \`target_table\` so the admin UI can render a bindings preview. \`auth.RuleAdminOnly\`.

No schema migration. 7-layer coverage with real bustest + apitest (not aspirational).

## Commits

1. \`feat(scenarios): add GET /v1/scenarios/{id}/fixtures endpoint\`
2. \`fix(seed): resolve product/location/tote refs at fixture seed time\`
3. \`test(scenarios): Load apitest returns 204 with resolvable fixture\`
4. \`docs(arch): note fixture-resolver step in seeding.md\`

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./business/sdk/dbtest/...\` — TestResolveRefs (7 subtests) PASS
- [x] \`go test ./api/cmd/services/ichor/tests/scenarios/scenarioapi/...\` — full suite including query, queryByID, active, fixtures, and new Load cases PASS
- [x] \`go test ./business/domain/scenarios/...\` — unchanged bus-level tests PASS
- [x] Load apitest: empty-state scenario → 204; scenario with pre-resolved fixture → 204; unknown id → 404; non-admin → 401

## Scope notes

\`deployments/scenarios/rush-receiving/state.yaml\` is emptied with an explanatory comment. Its prior rows needed resolvers (\`supplier_ref\`, \`warehouse_ref\`, \`currency_ref\`, \`user_ref\`, \`purchase_order_status_ref\`) that don't exist yet — Phase 1 authors those alongside the first real fixtures. The Load path works correctly with an empty state today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)