### PR TITLE
fix(approvalapi): include resolved_by and reason in retry Temporal payload

### DIFF
--- a/api/domain/http/workflow/approvalapi/approvalapi.go
+++ b/api/domain/http/workflow/approvalapi/approvalapi.go
@@ -405,11 +405,20 @@ func (a *api) retryTemporalCompletion(ctx context.Context, id uuid.UUID) web.Enc
 		return toAppApproval(approval)
 	}
 
+	resolvedBy := ""
+	if approval.ResolvedBy != nil {
+		resolvedBy = approval.ResolvedBy.String()
+	}
+
+	// Payload shape must match the primary resolve path so downstream workflow
+	// steps observe the same keys regardless of which path notified Temporal.
 	output := temporal.ActionActivityOutput{
 		ActionName: approval.ActionName,
 		Result: map[string]any{
 			"output":      approval.Status,
 			"approval_id": approval.ID.String(),
+			"resolved_by": resolvedBy,
+			"reason":      approval.ResolutionReason,
 		},
 		Success: true,
 	}

--- a/api/domain/http/workflow/approvalapi/approvalapi.go
+++ b/api/domain/http/workflow/approvalapi/approvalapi.go
@@ -199,6 +199,20 @@ func (a *api) resolve(ctx context.Context, r *http.Request) web.Encoder {
 	return toAppApproval(approval)
 }
 
+// buildResolveResult is the single source of truth for the Temporal activity
+// Result payload emitted by an approval resolution. Both the primary resolve
+// path and retryTemporalCompletion must go through this so downstream workflow
+// steps observe identical keys regardless of which path completed the activity.
+// Adding a field here forces every caller to supply it.
+func buildResolveResult(output, approvalID, resolvedBy, reason string) map[string]any {
+	return map[string]any{
+		"output":      output,
+		"approval_id": approvalID,
+		"resolved_by": resolvedBy,
+		"reason":      reason,
+	}
+}
+
 // completeAndClear sends the Temporal activity completion signal and removes the
 // task token from the DB. Called from resolve() on first-time resolution.
 // Errors from both operations are logged but not propagated (fail-open).
@@ -215,13 +229,8 @@ func (a *api) completeAndClear(ctx context.Context, id uuid.UUID, approval appro
 	}
 	output := temporal.ActionActivityOutput{
 		ActionName: approval.ActionName,
-		Result: map[string]any{
-			"output":      req.Resolution,
-			"approval_id": approval.ID.String(),
-			"resolved_by": userID.String(),
-			"reason":      req.Reason,
-		},
-		Success: true,
+		Result:     buildResolveResult(req.Resolution, approval.ID.String(), userID.String(), req.Reason),
+		Success:    true,
 	}
 	if err := a.asyncCompleter.Complete(ctx, taskToken, output); err != nil {
 		a.log.Error(ctx, "failed to complete Temporal activity",
@@ -410,17 +419,10 @@ func (a *api) retryTemporalCompletion(ctx context.Context, id uuid.UUID) web.Enc
 		resolvedBy = approval.ResolvedBy.String()
 	}
 
-	// Payload shape must match the primary resolve path so downstream workflow
-	// steps observe the same keys regardless of which path notified Temporal.
 	output := temporal.ActionActivityOutput{
 		ActionName: approval.ActionName,
-		Result: map[string]any{
-			"output":      approval.Status,
-			"approval_id": approval.ID.String(),
-			"resolved_by": resolvedBy,
-			"reason":      approval.ResolutionReason,
-		},
-		Success: true,
+		Result:     buildResolveResult(approval.Status, approval.ID.String(), resolvedBy, approval.ResolutionReason),
+		Success:    true,
 	}
 
 	if err := a.asyncCompleter.Complete(ctx, taskToken, output); err != nil {

--- a/api/domain/http/workflow/approvalapi/resolve_test.go
+++ b/api/domain/http/workflow/approvalapi/resolve_test.go
@@ -144,6 +144,8 @@ func TestRetryTemporalCompletion_EmptyToken(t *testing.T) {
 func TestRetryTemporalCompletion_TokenPresentCompleteSucceeds(t *testing.T) {
 	// When task_token is present and Complete() succeeds:
 	// Expect: Temporal called, ClearTaskToken called, approval returned.
+	// Payload must carry the same keys as the primary resolve path so
+	// downstream workflow steps see consistent context regardless of path.
 	approval := resolvedApproval(validToken())
 
 	storer := &mockStorer{queryByIDResult: approval}
@@ -162,6 +164,22 @@ func TestRetryTemporalCompletion_TokenPresentCompleteSucceeds(t *testing.T) {
 
 	if !storer.clearCalled {
 		t.Fatal("ClearTaskToken should have been called after successful Complete")
+	}
+
+	out, ok := completer.capturedOut.(temporal.ActionActivityOutput)
+	if !ok {
+		t.Fatalf("expected temporal.ActionActivityOutput, got %T", completer.capturedOut)
+	}
+	for _, key := range []string{"output", "approval_id", "resolved_by", "reason"} {
+		if _, present := out.Result[key]; !present {
+			t.Errorf("retry payload missing key %q; primary resolve path sets it", key)
+		}
+	}
+	if got := out.Result["resolved_by"]; got != approval.ResolvedBy.String() {
+		t.Errorf("resolved_by = %v, want %s", got, approval.ResolvedBy.String())
+	}
+	if got := out.Result["reason"]; got != approval.ResolutionReason {
+		t.Errorf("reason = %v, want %q", got, approval.ResolutionReason)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `retryTemporalCompletion` in `approvalapi.go` was omitting `resolved_by` and `reason` from the Temporal `ActionActivityOutput.Result` map, diverging from the primary `resolve()` path that carries all four keys. Any downstream workflow step reading those keys from the activity result saw empty values whenever the retry path fired.
- Originally flagged as Issue #9 in the review of #89 and shipped unresolved in #88.
- Pulls both values from the already-fetched `approval` struct (`ResolvedBy *uuid.UUID` nil-guarded; `ResolutionReason` string).

## Test plan

- `go test ./api/domain/http/workflow/approvalapi/ -run TestRetryTemporalCompletion -v` — all 5 subtests pass.
- Extended `TestRetryTemporalCompletion_TokenPresentCompleteSucceeds` asserts the captured Temporal output carries `output`, `approval_id`, `resolved_by`, `reason` and that their values match the fixture.
- `go build ./...` and `go vet ./...` clean.

🤖 Generated with https://claude.ai/code