### PR TITLE
fix(alerts): eliminate three twin-site payload drifts

### DIFF
--- a/api/cmd/services/ichor/build/all/all.go
+++ b/api/cmd/services/ichor/build/all/all.go
@@ -531,7 +531,7 @@ func (a add) Add(app *web.App, cfg mux.Config) {
 	// The core registration uses nil buses (graceful degradation); replace it here
 	// so that manual execution via POST /v1/workflow/actions/seek_approval/execute
 	// creates real approval request records.
-	actionRegistry.Register(approval.NewSeekApprovalHandler(cfg.Log, cfg.DB, approvalRequestBus, alertBus))
+	actionRegistry.Register(approval.NewSeekApprovalHandler(cfg.Log, cfg.DB, approvalRequestBus, alertBus, nil))
 
 	// Upgrade create_alert handler with real alert bus.
 	// The core registration uses nil buses (graceful degradation); replace it here

--- a/api/cmd/services/workflow-worker/main.go
+++ b/api/cmd/services/workflow-worker/main.go
@@ -203,7 +203,7 @@ func run(log *logger.Logger) error {
 
 	// Create async registry for human-in-the-loop actions.
 	asyncRegistry := temporal.NewAsyncRegistry()
-	asyncRegistry.Register("seek_approval", approval.NewSeekApprovalHandler(log, db, approvalRequestBus, alertBus))
+	asyncRegistry.Register("seek_approval", approval.NewSeekApprovalHandler(log, db, approvalRequestBus, alertBus, workflowQueue))
 
 	// =========================================================================
 	// Temporal Worker

--- a/api/cmd/tooling/admin/commands/validateworkflows.go
+++ b/api/cmd/tooling/admin/commands/validateworkflows.go
@@ -79,7 +79,7 @@ func createValidationRegistry() *workflow.ActionRegistry {
 
 	// Register handlers with nil dependencies - Validate() doesn't use them
 	registry.Register(data.NewUpdateFieldHandler(nil, nil))
-	registry.Register(approval.NewSeekApprovalHandler(nil, nil, nil, nil))
+	registry.Register(approval.NewSeekApprovalHandler(nil, nil, nil, nil, nil))
 	registry.Register(communication.NewSendEmailHandler(nil, nil, nil, ""))
 	registry.Register(communication.NewSendNotificationHandler(nil, nil))
 	registry.Register(communication.NewCreateAlertHandler(nil, nil, nil))

--- a/api/domain/http/workflow/alertapi/alertapi.go
+++ b/api/domain/http/workflow/alertapi/alertapi.go
@@ -20,6 +20,7 @@ import (
 	"github.com/timmaaaz/ichor/business/sdk/order"
 	"github.com/timmaaaz/ichor/business/sdk/page"
 	"github.com/timmaaaz/ichor/business/sdk/sqldb"
+	"github.com/timmaaaz/ichor/business/sdk/workflow/workflowactions/communication"
 	"github.com/timmaaaz/ichor/foundation/logger"
 	"github.com/timmaaaz/ichor/foundation/rabbitmq"
 	"github.com/timmaaaz/ichor/foundation/web"
@@ -345,29 +346,18 @@ func (a *api) testAlert(ctx context.Context, r *http.Request) web.Encoder {
 		return errs.Newf(errs.Internal, "create recipient: %s", err)
 	}
 
-	// Publish to RabbitMQ (if available) for WebSocket delivery
+	// Publish to RabbitMQ (if available) for WebSocket delivery. Build the
+	// WS payload from the same alertbus.Alert the HTTP response uses so
+	// both channels emit identical shapes.
 	if a.workflowQueue != nil {
-		alertPayload := map[string]interface{}{
-			"alert": map[string]interface{}{
-				"id":               alertID.String(),
-				"alertType":        "test_alert",
-				"severity":         severity,
-				"title":            title,
-				"message":          message,
-				"sourceEntityName": req.SourceEntityName,
-				"sourceEntityId":   sourceEntityID.String(),
-				"status":           alertbus.StatusActive,
-				"createdDate":      now.Format(time.RFC3339),
-				"updatedDate":      now.Format(time.RFC3339),
-			},
-		}
-
 		msg := &rabbitmq.Message{
 			Type:       "alert",
 			EntityName: "workflow.alerts",
 			EntityID:   alertID,
 			UserID:     userID,
-			Payload:    alertPayload,
+			Payload: map[string]interface{}{
+				"alert": communication.BuildAlertPayload(alert),
+			},
 		}
 
 		if err := a.workflowQueue.Publish(ctx, rabbitmq.QueueTypeAlert, msg); err != nil {

--- a/api/domain/http/workflow/alertws/consumer.go
+++ b/api/domain/http/workflow/alertws/consumer.go
@@ -61,6 +61,23 @@ func (ac *AlertConsumer) HandleMessage(ctx context.Context, msg *rabbitmq.Messag
 	return ac.handleAlert(ctx, msg)
 }
 
+// messageTypeForAlert maps a RabbitMQ message Type to the corresponding
+// WebSocket envelope MessageType. Every RabbitMQ Type that reaches this
+// consumer must have an explicit case so downstream clients can switch on a
+// stable, type-safe value. Adding a new publisher Type without adding a case
+// here causes the envelope to fall through to MessageTypeAlert — a silent
+// routing twin-site that prior audits (tasks/twin-site-audit.md) have flagged.
+func messageTypeForAlert(rabbitType string) websocket.MessageType {
+	switch rabbitType {
+	case "alert_updated":
+		return websocket.MessageTypeAlertUpdated
+	case "approval_resolved":
+		return websocket.MessageTypeApprovalResolved
+	default:
+		return websocket.MessageTypeAlert
+	}
+}
+
 // handleAlert processes a single alert message from RabbitMQ.
 func (ac *AlertConsumer) handleAlert(ctx context.Context, msg *rabbitmq.Message) error {
 	// Check for final failure (max retries exceeded)
@@ -95,11 +112,8 @@ func (ac *AlertConsumer) handleAlert(ctx context.Context, msg *rabbitmq.Message)
 		alertPayload = data
 	}
 
-	// Choose the message type: alert_updated for status changes, alert for new alerts.
-	msgType := websocket.MessageTypeAlert
-	if msg.Type == "alert_updated" {
-		msgType = websocket.MessageTypeAlertUpdated
-	}
+	// Map the RabbitMQ message type to the WebSocket envelope type.
+	msgType := messageTypeForAlert(msg.Type)
 
 	// Build WebSocket message envelope
 	wsMsg := websocket.Message{

--- a/api/domain/http/workflow/alertws/consumer_unit_test.go
+++ b/api/domain/http/workflow/alertws/consumer_unit_test.go
@@ -1,0 +1,29 @@
+package alertws
+
+import (
+	"testing"
+
+	"github.com/timmaaaz/ichor/foundation/websocket"
+)
+
+func TestMessageTypeForAlert(t *testing.T) {
+	tests := []struct {
+		rabbitType string
+		want       websocket.MessageType
+	}{
+		{rabbitType: "alert", want: websocket.MessageTypeAlert},
+		{rabbitType: "alert_updated", want: websocket.MessageTypeAlertUpdated},
+		{rabbitType: "approval_resolved", want: websocket.MessageTypeApprovalResolved},
+		{rabbitType: "", want: websocket.MessageTypeAlert},
+		{rabbitType: "unknown_type", want: websocket.MessageTypeAlert},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.rabbitType, func(t *testing.T) {
+			got := messageTypeForAlert(tt.rabbitType)
+			if got != tt.want {
+				t.Errorf("messageTypeForAlert(%q) = %q, want %q", tt.rabbitType, got, tt.want)
+			}
+		})
+	}
+}

--- a/api/domain/http/workflow/approvalapi/approvalapi.go
+++ b/api/domain/http/workflow/approvalapi/approvalapi.go
@@ -344,12 +344,11 @@ func (a *api) resolveUserNames(ctx context.Context, ids map[uuid.UUID]bool) map[
 	return nameMap
 }
 
-// publishApprovalResolved publishes a resolved approval event to RabbitMQ for WebSocket delivery.
-func (a *api) publishApprovalResolved(ctx context.Context, approval approvalrequestbus.ApprovalRequest, resolvedBy uuid.UUID) {
-	if a.workflowQueue == nil {
-		return
-	}
-
+// buildApprovalResolvedPayload is the single source of truth for the WebSocket
+// payload sent on an approval_resolved event. Adding a field here forces every
+// caller to supply it through the signature instead of growing an inline map
+// at a secondary site.
+func buildApprovalResolvedPayload(approval approvalrequestbus.ApprovalRequest, resolvedBy uuid.UUID) map[string]any {
 	payload := map[string]any{
 		"approvalId": approval.ID.String(),
 		"status":     approval.Status,
@@ -360,13 +359,21 @@ func (a *api) publishApprovalResolved(ctx context.Context, approval approvalrequ
 	if approval.ResolvedDate != nil {
 		payload["resolvedDate"] = approval.ResolvedDate.Format(time.RFC3339)
 	}
+	return payload
+}
+
+// publishApprovalResolved publishes a resolved approval event to RabbitMQ for WebSocket delivery.
+func (a *api) publishApprovalResolved(ctx context.Context, approval approvalrequestbus.ApprovalRequest, resolvedBy uuid.UUID) {
+	if a.workflowQueue == nil {
+		return
+	}
 
 	msg := &rabbitmq.Message{
 		Type:       "approval_resolved",
 		EntityName: "workflow.approval_requests",
 		EntityID:   approval.ID,
 		UserID:     resolvedBy,
-		Payload:    payload,
+		Payload:    buildApprovalResolvedPayload(approval, resolvedBy),
 	}
 
 	if err := a.workflowQueue.Publish(ctx, rabbitmq.QueueTypeAlert, msg); err != nil {

--- a/api/domain/http/workflow/approvalapi/publish_test.go
+++ b/api/domain/http/workflow/approvalapi/publish_test.go
@@ -1,0 +1,70 @@
+package approvalapi
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/timmaaaz/ichor/business/domain/workflow/approvalrequestbus"
+)
+
+// TestBuildApprovalResolvedPayload asserts the shape of the WebSocket payload
+// built for an approval_resolved event. If a new field is added to the shape,
+// every caller is forced to supply it through the signature.
+func TestBuildApprovalResolvedPayload(t *testing.T) {
+	resolvedBy := uuid.New()
+	resolvedDate := time.Date(2026, 4, 23, 10, 0, 0, 0, time.UTC)
+
+	approval := approvalrequestbus.ApprovalRequest{
+		ID:           uuid.New(),
+		RuleID:       uuid.New(),
+		ActionName:   "seek_approval_0",
+		Status:       approvalrequestbus.StatusApproved,
+		ResolvedDate: &resolvedDate,
+	}
+
+	got := buildApprovalResolvedPayload(approval, resolvedBy)
+
+	wantKeys := []string{"approvalId", "status", "resolvedBy", "ruleId", "actionName", "resolvedDate"}
+	for _, key := range wantKeys {
+		if _, ok := got[key]; !ok {
+			t.Errorf("payload missing key %q", key)
+		}
+	}
+
+	if got["approvalId"] != approval.ID.String() {
+		t.Errorf("approvalId = %v, want %s", got["approvalId"], approval.ID.String())
+	}
+	if got["status"] != approval.Status {
+		t.Errorf("status = %v, want %s", got["status"], approval.Status)
+	}
+	if got["resolvedBy"] != resolvedBy.String() {
+		t.Errorf("resolvedBy = %v, want %s", got["resolvedBy"], resolvedBy.String())
+	}
+	if got["ruleId"] != approval.RuleID.String() {
+		t.Errorf("ruleId = %v, want %s", got["ruleId"], approval.RuleID.String())
+	}
+	if got["actionName"] != approval.ActionName {
+		t.Errorf("actionName = %v, want %s", got["actionName"], approval.ActionName)
+	}
+	if got["resolvedDate"] != resolvedDate.Format(time.RFC3339) {
+		t.Errorf("resolvedDate = %v, want %s", got["resolvedDate"], resolvedDate.Format(time.RFC3339))
+	}
+}
+
+// TestBuildApprovalResolvedPayload_NoResolvedDate asserts resolvedDate is omitted
+// when the approval hasn't been resolved yet (nil pointer case).
+func TestBuildApprovalResolvedPayload_NoResolvedDate(t *testing.T) {
+	approval := approvalrequestbus.ApprovalRequest{
+		ID:         uuid.New(),
+		RuleID:     uuid.New(),
+		ActionName: "seek_approval_0",
+		Status:     approvalrequestbus.StatusPending,
+	}
+
+	got := buildApprovalResolvedPayload(approval, uuid.New())
+
+	if _, ok := got["resolvedDate"]; ok {
+		t.Error("resolvedDate should not be present when approval.ResolvedDate is nil")
+	}
+}

--- a/api/sdk/http/apitest/workflow.go
+++ b/api/sdk/http/apitest/workflow.go
@@ -77,7 +77,7 @@ func InitWorkflowInfra(t *testing.T, db *dbtest.Database) *WorkflowInfra {
 	w.RegisterWorkflow(temporal.ExecuteGraphWorkflow)
 	w.RegisterWorkflow(temporal.ExecuteBranchUntilConvergence)
 	asyncRegistry := temporal.NewAsyncRegistry()
-	asyncRegistry.Register("seek_approval", approval.NewSeekApprovalHandler(db.Log, db.DB, approvalBus, alertBus))
+	asyncRegistry.Register("seek_approval", approval.NewSeekApprovalHandler(db.Log, db.DB, approvalBus, alertBus, nil))
 
 	activities := &temporal.Activities{
 		Registry:      registry,

--- a/business/sdk/workflow/workflowactions/approval/seek.go
+++ b/business/sdk/workflow/workflowactions/approval/seek.go
@@ -12,7 +12,9 @@ import (
 	"github.com/timmaaaz/ichor/business/domain/workflow/alertbus"
 	"github.com/timmaaaz/ichor/business/domain/workflow/approvalrequestbus"
 	"github.com/timmaaaz/ichor/business/sdk/workflow"
+	"github.com/timmaaaz/ichor/business/sdk/workflow/workflowactions/communication"
 	"github.com/timmaaaz/ichor/foundation/logger"
+	"github.com/timmaaaz/ichor/foundation/rabbitmq"
 )
 
 // seekApprovalConfig represents the configuration for a seek_approval action.
@@ -29,16 +31,21 @@ type SeekApprovalHandler struct {
 	db                 *sqlx.DB
 	approvalRequestBus *approvalrequestbus.Business
 	alertBus           *alertbus.Business
+	workflowQueue      *rabbitmq.WorkflowQueue
 }
 
 // NewSeekApprovalHandler creates a new seek approval handler.
-// approvalRequestBus and alertBus can be nil for core registration (graceful degradation).
-func NewSeekApprovalHandler(log *logger.Logger, db *sqlx.DB, approvalRequestBus *approvalrequestbus.Business, alertBus *alertbus.Business) *SeekApprovalHandler {
+// approvalRequestBus, alertBus, and workflowQueue can be nil for core
+// registration (graceful degradation). workflowQueue enables real-time
+// WebSocket delivery of approval-request alerts; without it the alert is
+// still persisted in the DB and visible via REST polling.
+func NewSeekApprovalHandler(log *logger.Logger, db *sqlx.DB, approvalRequestBus *approvalrequestbus.Business, alertBus *alertbus.Business, workflowQueue *rabbitmq.WorkflowQueue) *SeekApprovalHandler {
 	return &SeekApprovalHandler{
 		log:                log,
 		db:                 db,
 		approvalRequestBus: approvalRequestBus,
 		alertBus:           alertBus,
+		workflowQueue:      workflowQueue,
 	}
 }
 
@@ -268,5 +275,11 @@ func (h *SeekApprovalHandler) createApprovalAlert(ctx context.Context, req appro
 		h.log.Error(ctx, "failed to create approval alert recipients",
 			"approval_request_id", req.ID,
 			"error", err)
+		return
 	}
+
+	// Deliver the alert over WebSocket so approvers are notified in real time.
+	// The DB write above is the source of truth; WS delivery is best-effort
+	// and a nil workflowQueue is a no-op (core registration / offline tests).
+	communication.PublishAlertToRecipients(ctx, h.workflowQueue, h.log, alert, recipients)
 }

--- a/business/sdk/workflow/workflowactions/approval/seek_test.go
+++ b/business/sdk/workflow/workflowactions/approval/seek_test.go
@@ -54,7 +54,7 @@ func insertSeekSeedData(db *dbtest.Database) (seekSeedData, error) {
 	approverB := uuid.New()
 
 	return seekSeedData{
-		Handler:            approval.NewSeekApprovalHandler(db.Log, db.DB, nil, db.BusDomain.Alert),
+		Handler:            approval.NewSeekApprovalHandler(db.Log, db.DB, nil, db.BusDomain.Alert, nil),
 		ApprovalRequestBus: nil,
 		AlertBus:           db.BusDomain.Alert,
 		Approvers:          []uuid.UUID{approverA, approverB},
@@ -80,7 +80,7 @@ func validateValidConfig(_ seekSeedData) unitest.Table {
 		ExpResp: nil,
 		ExcFunc: func(ctx context.Context) any {
 			log := logger.New(io.Discard, logger.LevelInfo, "test", nil)
-			handler := approval.NewSeekApprovalHandler(log, nil, nil, nil)
+			handler := approval.NewSeekApprovalHandler(log, nil, nil, nil, nil)
 
 			config := json.RawMessage(`{
 				"approvers": ["` + uuid.New().String() + `"],
@@ -104,7 +104,7 @@ func validateMissingApprovers(_ seekSeedData) unitest.Table {
 		ExpResp: "approvers list is required and must not be empty",
 		ExcFunc: func(ctx context.Context) any {
 			log := logger.New(io.Discard, logger.LevelInfo, "test", nil)
-			handler := approval.NewSeekApprovalHandler(log, nil, nil, nil)
+			handler := approval.NewSeekApprovalHandler(log, nil, nil, nil, nil)
 
 			config := json.RawMessage(`{
 				"approval_type": "any",
@@ -131,7 +131,7 @@ func validateEmptyApprovers(_ seekSeedData) unitest.Table {
 		ExpResp: "approvers list is required and must not be empty",
 		ExcFunc: func(ctx context.Context) any {
 			log := logger.New(io.Discard, logger.LevelInfo, "test", nil)
-			handler := approval.NewSeekApprovalHandler(log, nil, nil, nil)
+			handler := approval.NewSeekApprovalHandler(log, nil, nil, nil, nil)
 
 			config := json.RawMessage(`{
 				"approvers": [],
@@ -159,7 +159,7 @@ func validateInvalidApprovalType(_ seekSeedData) unitest.Table {
 		ExpResp: "invalid approval_type, must be: any, all, or majority",
 		ExcFunc: func(ctx context.Context) any {
 			log := logger.New(io.Discard, logger.LevelInfo, "test", nil)
-			handler := approval.NewSeekApprovalHandler(log, nil, nil, nil)
+			handler := approval.NewSeekApprovalHandler(log, nil, nil, nil, nil)
 
 			config := json.RawMessage(`{
 				"approvers": ["` + uuid.New().String() + `"],
@@ -187,7 +187,7 @@ func validateInvalidJSON(_ seekSeedData) unitest.Table {
 		ExpResp: true,
 		ExcFunc: func(ctx context.Context) any {
 			log := logger.New(io.Discard, logger.LevelInfo, "test", nil)
-			handler := approval.NewSeekApprovalHandler(log, nil, nil, nil)
+			handler := approval.NewSeekApprovalHandler(log, nil, nil, nil, nil)
 
 			config := json.RawMessage(`{not valid json}`)
 			err := handler.Validate(config)
@@ -221,7 +221,7 @@ func startAsyncNilBusReturnsError(_ seekSeedData) unitest.Table {
 		ExpResp: true,
 		ExcFunc: func(ctx context.Context) any {
 			log := logger.New(io.Discard, logger.LevelInfo, "test", nil)
-			handler := approval.NewSeekApprovalHandler(log, nil, nil, nil)
+			handler := approval.NewSeekApprovalHandler(log, nil, nil, nil, nil)
 
 			config := json.RawMessage(`{
 				"approvers": ["` + uuid.New().String() + `"],
@@ -268,7 +268,7 @@ func startAsyncInvalidApproverUUID(_ seekSeedData) unitest.Table {
 			// we use a real handler that will fail on UUID parse before DB call.
 			mockApprovalBus := approvalrequestbus.NewBusiness(log, nil, &noopApprovalStorer{})
 			mockAlertBus := alertbus.NewBusiness(log, &noopAlertStorer{})
-			handler := approval.NewSeekApprovalHandler(log, nil, mockApprovalBus, mockAlertBus)
+			handler := approval.NewSeekApprovalHandler(log, nil, mockApprovalBus, mockAlertBus, nil)
 
 			config := json.RawMessage(`{
 				"approvers": ["not-a-uuid"],
@@ -315,7 +315,7 @@ func executeNilBusGracefulDegradation(_ seekSeedData) unitest.Table {
 		ExpResp: "approved",
 		ExcFunc: func(ctx context.Context) any {
 			log := logger.New(io.Discard, logger.LevelInfo, "test", nil)
-			handler := approval.NewSeekApprovalHandler(log, nil, nil, nil)
+			handler := approval.NewSeekApprovalHandler(log, nil, nil, nil, nil)
 
 			config := json.RawMessage(`{
 				"approvers": ["` + uuid.New().String() + `"],
@@ -359,7 +359,7 @@ func executeInvalidApproverUUID(_ seekSeedData) unitest.Table {
 		ExcFunc: func(ctx context.Context) any {
 			log := logger.New(io.Discard, logger.LevelInfo, "test", nil)
 			mockApprovalBus := approvalrequestbus.NewBusiness(log, nil, &noopApprovalStorer{})
-			handler := approval.NewSeekApprovalHandler(log, nil, mockApprovalBus, nil)
+			handler := approval.NewSeekApprovalHandler(log, nil, mockApprovalBus, nil, nil)
 
 			config := json.RawMessage(`{
 				"approvers": ["not-a-uuid"],
@@ -406,7 +406,7 @@ func handlerProperties() unitest.Table {
 		ExpResp: "seek_approval|true|true",
 		ExcFunc: func(ctx context.Context) any {
 			log := logger.New(io.Discard, logger.LevelInfo, "test", nil)
-			handler := approval.NewSeekApprovalHandler(log, nil, nil, nil)
+			handler := approval.NewSeekApprovalHandler(log, nil, nil, nil, nil)
 
 			return fmt.Sprintf("%s|%v|%v", handler.GetType(), handler.IsAsync(), handler.SupportsManualExecution())
 		},
@@ -425,7 +425,7 @@ func handlerOutputPorts() unitest.Table {
 		ExpResp: 3,
 		ExcFunc: func(ctx context.Context) any {
 			log := logger.New(io.Discard, logger.LevelInfo, "test", nil)
-			handler := approval.NewSeekApprovalHandler(log, nil, nil, nil)
+			handler := approval.NewSeekApprovalHandler(log, nil, nil, nil, nil)
 			ports := handler.GetOutputPorts()
 			return len(ports)
 		},
@@ -464,7 +464,7 @@ func Test_SeekApprovalHandler_StartAsync_WithDB(t *testing.T) {
 	approverB := uuid.New()
 
 	approvalStore := approvalrequestbus.NewBusiness(db.Log, nil, newApprovalRequestStore(db))
-	handler := approval.NewSeekApprovalHandler(db.Log, db.DB, approvalStore, db.BusDomain.Alert)
+	handler := approval.NewSeekApprovalHandler(db.Log, db.DB, approvalStore, db.BusDomain.Alert, nil)
 
 	t.Run("creates_approval_request_with_task_token", func(t *testing.T) {
 		executionID := wfData.AutomationExecutions[0].ID

--- a/business/sdk/workflow/workflowactions/communication/alert.go
+++ b/business/sdk/workflow/workflowactions/communication/alert.go
@@ -242,60 +242,9 @@ func resolveTemplateVars(template string, data map[string]interface{}) string {
 	})
 }
 
-// publishAlertToWebSocket publishes alert messages to RabbitMQ for WebSocket delivery.
-// Each recipient gets a targeted message (user or role).
+// publishAlertToWebSocket delegates to the shared PublishAlertToRecipients
+// helper so this handler and other alert emitters (e.g. seek_approval) share a
+// single publishing path and payload shape.
 func (h *CreateAlertHandler) publishAlertToWebSocket(ctx context.Context, alert alertbus.Alert, recipients []alertbus.AlertRecipient) {
-	// Build the alert payload once (shared across all messages)
-	alertData := map[string]interface{}{
-		"id":               alert.ID.String(),
-		"alertType":        alert.AlertType,
-		"severity":         alert.Severity,
-		"title":            alert.Title,
-		"message":          alert.Message,
-		"status":           alert.Status,
-		"createdDate":      alert.CreatedDate.Format(time.RFC3339),
-		"updatedDate":      alert.UpdatedDate.Format(time.RFC3339),
-		"sourceEntityName": alert.SourceEntityName,
-		"context":          alert.Context,
-	}
-
-	// Only include sourceEntityId if it's not the zero UUID
-	if alert.SourceEntityID != uuid.Nil {
-		alertData["sourceEntityId"] = alert.SourceEntityID.String()
-	}
-
-	if alert.ActionURL != "" {
-		alertData["actionUrl"] = alert.ActionURL
-	}
-
-	for _, recipient := range recipients {
-		// Build payload with alert data
-		payload := map[string]interface{}{
-			"alert": alertData,
-		}
-
-		msg := &rabbitmq.Message{
-			Type:       "alert",
-			EntityName: "workflow.alerts",
-			EntityID:   alert.ID,
-		}
-
-		// Target by user or role
-		if recipient.RecipientType == "user" {
-			msg.UserID = recipient.RecipientID
-		} else if recipient.RecipientType == "role" {
-			payload["role_id"] = recipient.RecipientID.String()
-		}
-
-		msg.Payload = payload
-
-		if err := h.workflowQueue.Publish(ctx, rabbitmq.QueueTypeAlert, msg); err != nil {
-			h.log.Error(ctx, "failed to publish alert to rabbitmq",
-				"alert_id", alert.ID,
-				"recipient_type", recipient.RecipientType,
-				"recipient_id", recipient.RecipientID,
-				"error", err)
-			// Continue - alert is already persisted, log error but don't fail
-		}
-	}
+	PublishAlertToRecipients(ctx, h.workflowQueue, h.log, alert, recipients)
 }

--- a/business/sdk/workflow/workflowactions/communication/publish.go
+++ b/business/sdk/workflow/workflowactions/communication/publish.go
@@ -1,0 +1,99 @@
+package communication
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/timmaaaz/ichor/business/domain/workflow/alertbus"
+	"github.com/timmaaaz/ichor/foundation/logger"
+	"github.com/timmaaaz/ichor/foundation/rabbitmq"
+)
+
+// BuildAlertPayload is the single source of truth for the WebSocket JSON
+// payload shape used by every alert publisher. Key names and inclusion rules
+// must match the alertapi HTTP response (see api/domain/http/workflow/alertapi/model.go:toAppAlert)
+// so frontend subscribers receive the same shape on either channel.
+//
+// When adding a new field to alertbus.Alert that should reach the frontend,
+// add it here — not at individual publish sites — to prevent twin-site drift.
+func BuildAlertPayload(alert alertbus.Alert) map[string]interface{} {
+	payload := map[string]interface{}{
+		"id":          alert.ID.String(),
+		"alertType":   alert.AlertType,
+		"severity":    alert.Severity,
+		"title":       alert.Title,
+		"message":     alert.Message,
+		"status":      alert.Status,
+		"createdDate": alert.CreatedDate.Format(time.RFC3339),
+		"updatedDate": alert.UpdatedDate.Format(time.RFC3339),
+	}
+
+	if len(alert.Context) > 0 {
+		payload["context"] = alert.Context
+	}
+	if alert.SourceEntityName != "" {
+		payload["sourceEntityName"] = alert.SourceEntityName
+	}
+	if alert.SourceEntityID != uuid.Nil {
+		payload["sourceEntityId"] = alert.SourceEntityID.String()
+	}
+	if alert.SourceRuleID != uuid.Nil {
+		payload["sourceRuleId"] = alert.SourceRuleID.String()
+	}
+	if alert.SourceRuleName != "" {
+		payload["sourceRuleName"] = alert.SourceRuleName
+	}
+	if alert.ActionURL != "" {
+		payload["actionUrl"] = alert.ActionURL
+	}
+	if alert.ExpiresDate != nil {
+		payload["expiresDate"] = alert.ExpiresDate.Format(time.RFC3339)
+	}
+
+	return payload
+}
+
+// buildRecipientAlertMessage constructs the RabbitMQ Message for a single
+// alert recipient. Users are targeted via msg.UserID; roles via a "role_id"
+// key in the payload (the consumer reads it from there).
+func buildRecipientAlertMessage(alert alertbus.Alert, alertData map[string]interface{}, recipient alertbus.AlertRecipient) *rabbitmq.Message {
+	payload := map[string]interface{}{"alert": alertData}
+	msg := &rabbitmq.Message{
+		Type:       "alert",
+		EntityName: "workflow.alerts",
+		EntityID:   alert.ID,
+	}
+	switch recipient.RecipientType {
+	case "user":
+		msg.UserID = recipient.RecipientID
+	case "role":
+		payload["role_id"] = recipient.RecipientID.String()
+	}
+	msg.Payload = payload
+	return msg
+}
+
+// PublishAlertToRecipients publishes an alert to RabbitMQ (QueueTypeAlert) for
+// WebSocket delivery — one message per recipient. This is the single
+// alert-publishing seam; every site that creates a workflow alert should call
+// this instead of hand-rolling publish loops. Publish errors are logged but
+// not returned — the alert is already persisted and WS delivery is
+// best-effort. A nil publisher is a no-op (graceful degradation for tests and
+// core registrations).
+func PublishAlertToRecipients(ctx context.Context, publisher *rabbitmq.WorkflowQueue, log *logger.Logger, alert alertbus.Alert, recipients []alertbus.AlertRecipient) {
+	if publisher == nil {
+		return
+	}
+	alertData := BuildAlertPayload(alert)
+	for _, recipient := range recipients {
+		msg := buildRecipientAlertMessage(alert, alertData, recipient)
+		if err := publisher.Publish(ctx, rabbitmq.QueueTypeAlert, msg); err != nil {
+			log.Error(ctx, "failed to publish alert to rabbitmq",
+				"alert_id", alert.ID,
+				"recipient_type", recipient.RecipientType,
+				"recipient_id", recipient.RecipientID,
+				"error", err)
+		}
+	}
+}

--- a/business/sdk/workflow/workflowactions/communication/publish_test.go
+++ b/business/sdk/workflow/workflowactions/communication/publish_test.go
@@ -1,0 +1,153 @@
+package communication
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/timmaaaz/ichor/business/domain/workflow/alertbus"
+)
+
+// TestBuildAlertPayload_AllFields asserts every alertbus.Alert field that has
+// a corresponding alertapi HTTP-visible JSON tag appears in the WS payload,
+// so frontend subscribers receive the same shape from either channel.
+func TestBuildAlertPayload_AllFields(t *testing.T) {
+	created := time.Date(2026, 4, 23, 10, 0, 0, 0, time.UTC)
+	updated := time.Date(2026, 4, 23, 10, 5, 0, 0, time.UTC)
+	expires := time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)
+
+	alert := alertbus.Alert{
+		ID:               uuid.New(),
+		AlertType:        "test_alert",
+		Severity:         alertbus.SeverityHigh,
+		Title:            "Test",
+		Message:          "This is a test",
+		Context:          json.RawMessage(`{"foo":"bar"}`),
+		SourceEntityName: "orders",
+		SourceEntityID:   uuid.New(),
+		SourceRuleID:     uuid.New(),
+		SourceRuleName:   "Rule 1",
+		ActionURL:        "/orders/123",
+		Status:           alertbus.StatusActive,
+		ExpiresDate:      &expires,
+		CreatedDate:      created,
+		UpdatedDate:      updated,
+	}
+
+	got := BuildAlertPayload(alert)
+
+	// Every HTTP-visible field must appear in the WS payload.
+	wantKeys := []string{
+		"id", "alertType", "severity", "title", "message",
+		"context", "sourceEntityName", "sourceEntityId",
+		"sourceRuleId", "sourceRuleName", "actionUrl",
+		"status", "expiresDate", "createdDate", "updatedDate",
+	}
+	for _, key := range wantKeys {
+		if _, ok := got[key]; !ok {
+			t.Errorf("payload missing key %q — frontend subscriber will see undefined", key)
+		}
+	}
+
+	if got["id"] != alert.ID.String() {
+		t.Errorf("id = %v, want %s", got["id"], alert.ID.String())
+	}
+	if got["sourceRuleId"] != alert.SourceRuleID.String() {
+		t.Errorf("sourceRuleId = %v, want %s", got["sourceRuleId"], alert.SourceRuleID.String())
+	}
+	if got["actionUrl"] != alert.ActionURL {
+		t.Errorf("actionUrl = %v, want %s", got["actionUrl"], alert.ActionURL)
+	}
+	if got["expiresDate"] != expires.Format(time.RFC3339) {
+		t.Errorf("expiresDate = %v, want %s", got["expiresDate"], expires.Format(time.RFC3339))
+	}
+}
+
+// TestBuildRecipientAlertMessage_User asserts user-targeted messages carry
+// msg.UserID set and do NOT stuff the user UUID into the payload.
+func TestBuildRecipientAlertMessage_User(t *testing.T) {
+	alert := alertbus.Alert{ID: uuid.New()}
+	alertData := map[string]interface{}{"id": alert.ID.String()}
+	userID := uuid.New()
+	recipient := alertbus.AlertRecipient{
+		RecipientType: "user",
+		RecipientID:   userID,
+	}
+
+	got := buildRecipientAlertMessage(alert, alertData, recipient)
+
+	if got.Type != "alert" {
+		t.Errorf("Type = %q, want %q", got.Type, "alert")
+	}
+	if got.UserID != userID {
+		t.Errorf("UserID = %v, want %v", got.UserID, userID)
+	}
+	if got.EntityID != alert.ID {
+		t.Errorf("EntityID = %v, want %v", got.EntityID, alert.ID)
+	}
+	if _, ok := got.Payload["role_id"]; ok {
+		t.Error("user-targeted message should not carry role_id in payload")
+	}
+	if _, ok := got.Payload["alert"]; !ok {
+		t.Error("payload missing `alert` key")
+	}
+}
+
+// TestBuildRecipientAlertMessage_Role asserts role-targeted messages leave
+// msg.UserID zero and set role_id in the payload (the consumer reads it from there).
+func TestBuildRecipientAlertMessage_Role(t *testing.T) {
+	alert := alertbus.Alert{ID: uuid.New()}
+	alertData := map[string]interface{}{"id": alert.ID.String()}
+	roleID := uuid.New()
+	recipient := alertbus.AlertRecipient{
+		RecipientType: "role",
+		RecipientID:   roleID,
+	}
+
+	got := buildRecipientAlertMessage(alert, alertData, recipient)
+
+	if got.UserID != uuid.Nil {
+		t.Errorf("UserID should be zero for role-targeted messages, got %v", got.UserID)
+	}
+	gotRoleID, ok := got.Payload["role_id"].(string)
+	if !ok {
+		t.Fatalf("payload.role_id missing or wrong type: %v", got.Payload["role_id"])
+	}
+	if gotRoleID != roleID.String() {
+		t.Errorf("role_id = %q, want %q", gotRoleID, roleID.String())
+	}
+}
+
+// TestBuildAlertPayload_OmitsZeroOptional asserts optional fields with zero
+// values are absent (matches the `omitempty` JSON tag behavior of alertapi.Alert).
+func TestBuildAlertPayload_OmitsZeroOptional(t *testing.T) {
+	alert := alertbus.Alert{
+		ID:          uuid.New(),
+		AlertType:   "test_alert",
+		Severity:    alertbus.SeverityLow,
+		Title:       "Minimal",
+		Message:     "Minimal alert",
+		Status:      alertbus.StatusActive,
+		CreatedDate: time.Now(),
+		UpdatedDate: time.Now(),
+		// Intentionally unset: Context, SourceEntityID, SourceRuleID, SourceEntityName,
+		// SourceRuleName, ActionURL, ExpiresDate.
+	}
+
+	got := BuildAlertPayload(alert)
+
+	mustAbsent := []string{"sourceEntityId", "sourceRuleId", "sourceEntityName", "sourceRuleName", "actionUrl", "expiresDate"}
+	for _, key := range mustAbsent {
+		if _, ok := got[key]; ok {
+			t.Errorf("payload should omit zero-value optional key %q, got %v", key, got[key])
+		}
+	}
+
+	mustPresent := []string{"id", "alertType", "severity", "title", "message", "status", "createdDate", "updatedDate"}
+	for _, key := range mustPresent {
+		if _, ok := got[key]; !ok {
+			t.Errorf("payload missing required key %q", key)
+		}
+	}
+}

--- a/business/sdk/workflow/workflowactions/register.go
+++ b/business/sdk/workflow/workflowactions/register.go
@@ -82,7 +82,7 @@ func RegisterAll(registry *workflow.ActionRegistry, config ActionConfig) {
 	registry.Register(data.NewAuditLogHandler(config.Log, config.DB))
 
 	// Approval actions
-	registry.Register(approval.NewSeekApprovalHandler(config.Log, config.DB, config.Buses.ApprovalRequest, config.Buses.Alert))
+	registry.Register(approval.NewSeekApprovalHandler(config.Log, config.DB, config.Buses.ApprovalRequest, config.Buses.Alert, config.QueueClient))
 	registry.Register(approval.NewResolveApprovalHandler(config.Log, config.Buses.ApprovalRequest))
 
 	// Communication actions
@@ -187,7 +187,7 @@ func RegisterCoreActions(registry *workflow.ActionRegistry, log *logger.Logger, 
 	registry.Register(data.NewAuditLogHandler(log, db))
 
 	// Approval actions - nil buses for core path (graceful degradation)
-	registry.Register(approval.NewSeekApprovalHandler(log, db, nil, nil))
+	registry.Register(approval.NewSeekApprovalHandler(log, db, nil, nil, nil))
 	registry.Register(approval.NewResolveApprovalHandler(log, nil))
 
 	// Communication actions that don't need queue or email client (nil = graceful degradation)

--- a/docs/arch/domain-template.md
+++ b/docs/arch/domain-template.md
@@ -104,6 +104,19 @@ table: {schema}.{table}
   business/domain/{area}/{entity}bus/{entity}bus.go               (bus model if exposed in API)
   app/domain/{area}/{entity}app/model.go                          (app model + toBus*/ToApp* conversions)
 
+## ⚠ Adding a second writer to a shared payload (twin-site drift)
+
+rule: two sites feeding the same `map[string]any` consumer → use a typed struct or shared builder, never inline literals
+
+existing shared builders:
+  api/domain/http/{area}/{entity}api/{entity}api.go : toApp{Entity}                 (HTTP response shape)
+  business/domain/{area}/{entity}bus/event.go : ActionCreated/Updated/DeletedData   (delegate event payload)
+  api/domain/http/workflow/approvalapi/approvalapi.go : buildResolveResult           (Temporal activity Result)
+  business/sdk/workflow/workflowactions/communication/alert.go : BuildAlertPayload   (WebSocket alert shape)
+
+incident: PR #126 — retry Temporal path dropped resolved_by/reason
+audit: tasks/twin-site-audit.md
+
 ## ⚠ Adding a new domain entity (full 7-layer checklist)
 
   business/domain/{area}/{entity}bus/{entity}bus.go               (Business struct + CRUD methods)

--- a/foundation/websocket/message.go
+++ b/foundation/websocket/message.go
@@ -13,8 +13,8 @@ const (
 	MessageTypeAlert MessageType = "alert"
 	// MessageTypeAlertUpdated signals that an existing alert's status changed.
 	MessageTypeAlertUpdated MessageType = "alert_updated"
-	// MessageTypeApprovalUpdated signals that an approval request was resolved.
-	MessageTypeApprovalUpdated MessageType = "approval_updated"
+	// MessageTypeApprovalResolved signals that an approval request was resolved (approved or rejected).
+	MessageTypeApprovalResolved MessageType = "approval_resolved"
 	// MessageTypePing is a heartbeat ping message.
 	MessageTypePing MessageType = "ping"
 	// MessageTypePong is a heartbeat pong response message.

--- a/tasks/twin-site-audit.md
+++ b/tasks/twin-site-audit.md
@@ -1,0 +1,172 @@
+# Twin-Site Payload Drift Audit
+
+**Date:** 2026-04-23
+**Scope:** Ichor Go codebase. Read-only audit.
+**Trigger:** PR #126 fixed a twin-site drift bug in `api/domain/http/workflow/approvalapi` where primary + retry paths each constructed a Temporal `Result: map[string]any{...}` inline and the retry path silently dropped `resolved_by` / `reason`.
+
+**Pattern recap.** Two or more code paths build inline literals (`map[string]any`, struct-with-untyped-field, JSON payload) that a single downstream reader consumes via string keys or reflection. No shared type, helper, or schema forces the shapes to agree. Fields drift silently when one site grows and the other does not. `map[string]any` and `interface{}` erase shape, so the compiler cannot help. Tests usually assert behavior at each site in isolation, not parity between sites.
+
+**Methodology.** Six parallel investigation agents, one per surface. Each read the authoritative arch doc first, then grepped for construction sites + downstream consumers. Top findings spot-checked against the source before elevation in the ranking below.
+
+---
+
+## Top 3 candidates to fix first
+
+1. **`approvalapi.publishApprovalResolved` WebSocket payload routing mismatch** (`api/domain/http/workflow/approvalapi/approvalapi.go:348`).
+   The publisher sets `msg.Type = "approval_resolved"` with fields at the top of `msg.Payload` (`approvalId`, `status`, `resolvedBy`, `ruleId`, `actionName`). The WebSocket consumer (`consumer.go:99-101`) only switches on `"alert_updated"`; every other type — including `"approval_resolved"` — falls through to the default branch and is delivered as WS type `"alert"` with the raw approval payload inside. Frontend `"alert"` subscribers expect keys `id`, `severity`, `message`, `alertType`, etc.; they receive `approvalId`, `resolvedBy`, `ruleId` instead and every access silently returns `undefined`. This is the *same class* of bug as PR #126 and has a live production impact: approval-resolved WebSocket notifications are structurally broken for any frontend keying on the alert schema.
+   **Why first:** HIGH severity, UNGUARDED, actively on the hot path, one-line audit surface.
+
+2. **`seek_approval` approval-created notification never reaches the WebSocket hub** (`business/sdk/workflow/workflowactions/approval/seek.go:216-272`, confirmed by direct read).
+   `createApprovalAlert` writes a row to `alertBus` and attaches recipients, but (unlike `CreateAlertHandler.publishAlertToWebSocket` in `business/sdk/workflow/workflowactions/communication/alert.go:247`) it never publishes to RabbitMQ / the hub. Result: an approver user has no real-time notification that a new approval request is waiting for them. They must poll. This is a twin-site by omission — two code paths that both create alerts and *should* both push, but only one does.
+   **Why second:** HIGH severity, UNGUARDED, affects the approval UX directly.
+
+3. **`alertapi.testAlert` ships two divergent shapes of the same alert** (`api/domain/http/workflow/alertapi/alertapi.go:350-363` vs `alertapi.go:379`).
+   The handler returns `toAppAlert(alert)` to the HTTP caller (14 fields) and publishes an inline `map[string]interface{}` to the WebSocket channel (9 fields). Missing from the WS push: `context`, `sourceRuleId`, `sourceRuleName`, `actionUrl`, `expiresDate`. The frontend alert tray consumes both channels; if it updates store state from the WS push (the common SSE/WS pattern), those 5 fields silently vanish from reactive state until a refetch. **Zero tests** exercise this endpoint at all.
+   **Why third:** HIGH severity, UNGUARDED, and it's an exact structural match for the PR #126 pattern — canonical `toAppX` function exists, a second site hand-rolls a near-duplicate.
+
+The following sections enumerate findings surface-by-surface.
+
+---
+
+## Surface 1: Delegate event publishing & registrations
+
+Arch doc: `docs/arch/delegate.md`. Scope combined surfaces 1 + 7 from the master brief (emitters + handler registrations share the same `DelegateEventParams` contract).
+
+| # | Site A (emitter) | Site B / Consumer | Consumer | Severity | Test-guarded? |
+|---|---|---|---|---|---|
+| 1 | `approvalrequestbus/event.go:22-52` — `ActionUpdatedParms` struct omits `UserID`; emitted by `approvalrequestbus.go:143` | Conforming consumer `business/sdk/workflow/temporal/delegatehandler.go:50-64` (`json.Unmarshal` into `workflow.DelegateEventParams`, reads `params.UserID`) | `delegatehandler.go:63` assigns `params.UserID` → `TriggerEvent.UserID` | MEDIUM (latent — `approvalrequest` domain is not currently wired via `RegisterDomain`, so mismatched payload is not actively delivered) | UNGUARDED — `delegate_test.go:62-90` checks `capturedDomain`/`capturedAction` only, never decodes `RawParams` |
+| 2 | `settingsbus/event.go` — all three `ActionXxxParms` structs use `Key string` instead of `EntityID uuid.UUID`, omit `UserID` | Same `delegatehandler.go` consumer shape | `params.EntityID` → `uuid.Nil`; `params.UserID` → `uuid.Nil` | LOW — no `RegisterDomain` for `"config.settings"` in `all.go` | UNGUARDED — no delegate-specific test for settingsbus |
+| 3 | `business/sdk/workflow/trigger.go:516` registers a consumer for `ActionRuleDeleted` | `workflowbus.go` never emits `ActionRuleDeleted` | Handler (`trigger.go:507-511`) only calls `RefreshRules`, ignores `RawParams` | LOW — dead registration; can't trigger | N/A |
+
+**Summary.** The latent risk is the `approvalrequestbus` payload: the moment someone adds `workflow.RegisterDomain` for `"approvalrequest"`, every approval-resolve event silently delivers `UserID = uuid.Nil` to the workflow engine. Testing hygiene would not catch this. The other two findings are defensively harmless today.
+
+**Checked and cleared.**
+- ~68 other registered domains (ordersbus, userbus, assetbus, productbus, warehousebus, etc.) all use the standard `ActionCreatedParms` / `ActionUpdatedParms` / `ActionDeletedParms` shape with `EntityID`, `UserID`, `Entity`, `BeforeEntity`. All `delegate.Call` sites go through the `ActionXxxData` helper — no inline map literals.
+- `workflowbus` `ActionRuleChangedParms` — single emitter, single consumer that ignores payload beyond `data.Action`.
+- `scenariobus` — registered; standard shape; `EntityID`/`UserID` explicitly `uuid.Nil` as documented limitation.
+
+---
+
+## Surface 2: Temporal activity payloads
+
+Arch doc: `docs/arch/workflow-engine.md`. Scope: `temporal.ActionActivityOutput` and `AsyncCompleter` construction sites beyond approvalapi.
+
+| # | Site A | Site B | Consumer | Severity | Test-guarded? |
+|---|---|---|---|---|---|
+| 1 | `seek_approval` async completion via `approvalapi.completeAndClear` → `buildResolveResult` (keys: `output`, `approval_id`, `resolved_by`, `reason`) `approvalapi.go:207-213` | `seek_approval` synchronous-fallback `Execute()` path (keys: `approval_id`, `output`, `status`) `seek.go:208-212` | `GraphExecutor` / `MergedContext` reads `result["output"]` for edge routing; downstream steps read other keys from `ActionResults` | MEDIUM — sync path drops `resolved_by` / `reason`; only bites if a workflow runs in manual-execution mode and a downstream step templates those fields | PARTIALLY GUARDED — `resolve_test.go:173` checks the async shape; `seek_test.go:529` checks `approval_id` but never compares the two shapes |
+| 2 | `seek_approval.Execute()` stub path (nil `approvalRequestBus`): `{"output":"approved","status":"stub"}` `seek.go:163-165` | `seek_approval.Execute()` real path: `{"approval_id":..., "output":"pending", "status":"pending"}` `seek.go:208-212` | Same `GraphExecutor` — same `Execute()` method, two inline branches | MEDIUM — stub path has no `approval_id`; template resolution like `{{seek_approval_0.approval_id}}` silently renders empty | UNGUARDED — no cross-branch test |
+| 3 | `send_email.Execute()` payload `email.go:130-136` | No second writer — `IsAsync()=true` but no `StartAsync`, routed through `ExecuteActionActivity` via `selectActivityFunc` | N/A | LOW — stale annotation; a future dev could register it async and create a twin | GUARDED by `allocate_inventory_async_test.go:33-37` (routing asserted) |
+| 4 | `allocate_inventory.Execute()` inline map `allocate.go:377-386` | Same story — `IsAsync()=true` but no `StartAsync`, routed sync | N/A | LOW — same stale-annotation risk | GUARDED by `allocate_inventory_async_test.go:84-114` |
+
+**Summary.** The approvalapi primary-vs-retry pair (the PR #126 bug) is now fixed by `buildResolveResult()`. The remaining live twin-site risk is `seek_approval.Execute()` having two distinct inline maps across `{nil-bus, real-bus}` branches whose key sets diverge, and the async vs sync-fallback shapes for the same action not matching. The `IsAsync()` stale annotations on `send_email` / `allocate_inventory` are documentation bugs today — they become real twin-sites if someone implements `StartAsync` for them without realizing the sync `Execute()` contract diverges.
+
+**Checked and cleared.**
+- `approvalapi.completeAndClear` + `retryTemporalCompletion` — both call `buildResolveResult()` now; deeply guarded in `resolve_test.go:173-183`.
+- `ExecuteActionActivity` return path (`activities.go:86-91`) — single construction site; `toResultMap` + `output` default injection are the only transforms.
+- `ExecuteAsyncActionActivity` — returns empty `ActionActivityOutput{}` with `activity.ErrResultPending`; the real payload is supplied later by `AsyncCompleter.Complete()`, which has one construction site in `approvalapi`.
+- `AsyncCompleter.Complete` / `Fail` — delegate to `client.CompleteActivity`; `Fail` passes `nil` result intentionally; no field-level drift.
+- All 19 other sync-only `ActionHandler.Execute()` implementations — single return site each; no async completion twin.
+
+---
+
+## Surface 3: Workflow action handlers / MergedContext
+
+Arch doc: `docs/arch/workflow-engine.md`. Scope: the 20 registered action types and the `MergedContext` they feed.
+
+| # | Site A | Site B | Consumer | Severity | Test-guarded? |
+|---|---|---|---|---|---|
+| 1 | `seek.go:163-166` stub path: `{"output":"approved","status":"stub"}` (no `approval_id`) | `seek.go:208-212` real path: `{"approval_id":..., "output":"pending", "status":"pending"}` | Downstream templating `{{seek_approval_0.approval_id}}` or edge routing on `output` | HIGH — stub emits `output=approved` with no `approval_id`; downstream edge divergence + empty template | UNGUARDED — `seek_test.go:312-352` asserts each path in isolation, never cross-path key-set parity |
+| 2 | `seek.go:85-88` `GetOutputPorts` declares `approved / rejected / timed_out` | `seek.go:208-212` `Execute()` emits `output=pending` | `graph_executor.go` routes on `result["output"]`; `pending` matches no edge, so `activities.go:76-78` substitutes `success`, silently bypassing approval branch logic | HIGH (in manual-execution mode; N/A for normal async-via-Temporal flow where StartAsync dispatches and Execute is not called) | UNGUARDED — no test asserts `Execute()`'s `output` value is a declared port name |
+| 3 | `commit_allocation.go:186-194` returns `CommitAllocationResult` (keys: `quantity_committed`, `previous_reserved`, `new_allocated`) | `release_reservation.go:178-184` returns `ReleaseReservationResult` (keys: `quantity_released`, `previous_reserved`, `new_reserved`) | Both are inventory-lifecycle handlers; a downstream `log_audit_entry` or `evaluate_condition` templating either's `quantity_*` field | MEDIUM — conceptually symmetric twin but different field names; cross-chain templates silently get zero for the missing field | UNGUARDED — DB-side-effect-only assertions; neither test inspects the returned map keys |
+| 4 | `allocate.go:377-386` `Execute()` returns map with `allocation_id` + `output` | `reserve_inventory.go:144-216` returns `ReserveInventoryResult` struct (keys: `reservation_id`, `status`, `reserved_items`, no `output`) | Downstream `evaluate_condition` templating `{{reserve_inventory.allocation_id}}` or `{{allocate_inventory.reservation_id}}` | MEDIUM — different ID key names; `output` missing on reserve path (default-injected) | UNGUARDED — `reserve_inventory_test.go` checks `result.Status` on the struct, never the map shape |
+
+**Summary.** Both top findings center on `seek_approval`, which is the most structurally twin-site-prone handler in the registry because it has: (a) nil-bus stub branch, (b) real-bus sync branch, (c) async completion via approvalapi — three code paths, three shapes, one consumer. The inventory-pair (commit/release, allocate/reserve) drift is cosmetic today but will accumulate as more workflows chain these handlers.
+
+**Checked and cleared** (single-writer, stable key sets, no downstream twin):
+- `check_inventory`, `check_reorder_point`, `evaluate_condition`, `delay`, `log_audit_entry`, `create_entity`, `lookup_entity`, `transition_status`, `update_field`, `call_webhook`, `create_alert`, `send_email`, `send_notification`, `create_purchase_order`, `receive_inventory`, `create_put_away_task`, `resolve_approval_request` — all verified single-writer or single-function-multi-branch with consistent skeleton.
+
+---
+
+## Surface 4: WebSocket alert payloads
+
+Arch doc: `docs/arch/workflow-alerts.md`.
+
+| # | Site A | Site B | Consumer | Severity | Test-guarded? |
+|---|---|---|---|---|---|
+| 1 | `seek.go:216-272` `createApprovalAlert()` — persists to DB via `alertBus.Create`, **never publishes to RabbitMQ / hub** (verified) | `communication/alert.go:247` `publishAlertToWebSocket()` — correctly publishes to hub | `consumer.go:76` `handleAlert()` → `BroadcastToUser/Role/All` | HIGH — approval-request alerts silently dark in the browser; users must poll REST | UNGUARDED — no test verifies `seek_approval` delivers a WS alert |
+| 2 | `approvalapi.go:348` `publishApprovalResolved()` — `msg.Type = "approval_resolved"` with top-level `approvalId`, `status`, `resolvedBy`, `ruleId`, `actionName`, `resolvedDate` | `consumer.go:99-101` — only branches on `"alert_updated"`; everything else falls through to WS type `"alert"` | `consumer.go:105` forwards raw `msg.Payload` under WS type `"alert"`; frontend `"alert"` handlers expect `id`, `severity`, `message`, `alertType` — they get `approvalId`, `resolvedBy` instead | HIGH — approval-resolved notifications structurally broken for any frontend keying on the canonical alert schema | UNGUARDED — `consumer_test.go` and `e2e_test.go` publish raw messages manually, never invoke this publisher |
+| 3 | `alertapi.go:500` `publishAlertStatusChange()` — wraps `{ "alertUpdate": { "id", "status", "updatedDate" } }` | N/A — single writer for `alert_updated` | `consumer.go:100` routes on `msg.Type == "alert_updated"` | LOW — single writer, no drift risk | UNGUARDED for content, but no twin-site |
+
+**Summary.** Two HIGH-severity live bugs in the alert pipeline. The first (`seek.go` creating a DB-only alert with no WS publish) is a *twin-site by omission*: the well-formed sibling (`CreateAlertHandler`) performs both writes, and the approval variant forgot the second. The second (`publishApprovalResolved` routing mismatch) is a textbook PR #126 pattern — emitter and consumer agreed verbally but not structurally.
+
+**Checked and cleared.**
+- `alert_updated` status-change alerts — single writer, correctly routed.
+- `create_alert` workflow action — single-writer end-to-end pipeline.
+- WebSocket hub targeting (`BroadcastToUser/Role/All`) — deterministic routing on `msg.UserID` / `msg.Payload["role_id"]`, no drift.
+
+---
+
+## Surface 5: HTTP response encoders vs. toApp* functions
+
+Scope: `api/domain/http/**`. Arch docs: `docs/arch/domain-template.md`, `docs/arch/errs.md`.
+
+| # | Site A (primary path) | Site B (secondary) | Consumer | Severity | Test-guarded? |
+|---|---|---|---|---|---|
+| 1 | `alertapi.go:379` returns `toAppAlert(alert)` (HTTP response from `testAlert`) | `alertapi.go:350-363` — inline `map[string]interface{}` published to RabbitMQ/WS from the same handler | Frontend alert tray (POST `/v1/workflow/alerts/test`) | HIGH — WS payload missing 5 canonical fields (`context`, `sourceRuleId`, `sourceRuleName`, `actionUrl`, `expiresDate`) | UNGUARDED — zero tests for this endpoint |
+| 2 | `alertapi.go:232` `acknowledge` returns `toAppAlert(alert)` | `alertapi.go:500-518` `publishAlertStatusChange` — inline `{ "alertUpdate": { id, status, updatedDate } }` | Frontend tray (POST `/v1/workflow/alerts/{id}/acknowledge` & `/dismiss`) | MEDIUM — architecturally a delta-update pattern, so the shape gap is intentional; frontend must handle partial-merge correctly | PARTIALLY GUARDED — bulk endpoint asserts `BulkActionResult`; single-alert WS shape has no typed assertion |
+| 3 | `approvalapi.go:199` `resolve` returns `toAppApproval(approval)` | `approvalapi.go:353-360` `publishApprovalResolved` — inline map | Frontend approval queue UI | MEDIUM — notification event rather than canonical entity payload; HTTP path is test-guarded, WS side untested | HTTP: GUARDED (`resolve_test.go` typed struct); WS: UNGUARDED |
+
+**Summary.** Two distinct HIGH-severity patterns, one in `alertapi.testAlert` (exact PR #126 structural match — canonical `toApp*` + hand-rolled sibling), and the other a thematic companion in `acknowledge`/`dismiss` where the WS shape is an intentional delta but is not asserted anywhere. `approvalapi` has the same pattern as `alertapi.testAlert` but the approval entity is more defensively typed on the frontend.
+
+**Checked and cleared.**
+- `workflow/approvalapi` retry paths — consistently call `toAppApproval` after PR #126.
+- `workflow/executionapi`, `workflow/ruleapi`, `workflow/workflowsaveapi`, `workflow/ruleapi/simulate.go` — single converter each, no secondary inline path.
+- `inventory/transferorderapi`, `putawaytaskapi`, `picktaskapi`, `cyclecountitemapi`, `cyclecountsessionapi` — straight CRUD, no branching response paths.
+- `sales/ordersapi`, `procurement/purchaseorderapi`, `floor/directedworkapi` — app-layer result returned directly, no inline twin.
+
+---
+
+## Surface 6: Form data / template processing
+
+Arch doc: `docs/arch/form-data.md`.
+
+| # | Site A | Site B | Consumer | Severity | Test-guarded? |
+|---|---|---|---|---|---|
+| 1 | `mergeFieldDefaults` (`formdataapp.go:500-588`) — parses `formfieldbus.FieldDefaultConfig` for `DefaultValue`, `DefaultValueCreate`, `DefaultValueUpdate`, `CopyFromField` + ad-hoc anonymous struct for dropdown FKs | `mergeLineItemFieldDefaults` (`formdataapp.go:623-685`) — reads the same logical fields but directly from `formfieldbus.LineItemField` | `ProcessTemplateObject` at `formdataapp.go:335`, reached by both `executeSingleOperation` and `executeArrayOperation` | HIGH — no shared extraction helper; any new default-injection field added to one function must be mirrored manually. `FieldDefaultConfig` is even a named type that `LineItemField` inlines field-by-field. Observationally symmetric today but structurally unenforced | PARTIALLY GUARDED — `TestMergeLineItemFieldDefaults` asserts injected values without `CopyFromField` cases; `TestMergeFieldDefaults_*` covers the non-line-item path including FK resolution; no test uses both functions with the same fixture to assert parity |
+| 2 | `updateOrderTotals` (`formdataapp.go:808-828`) — inline `map[string]any{"id": ..., "subtotal": ..., "tax_amount": ..., "total_amount": ...}` → `executeUpdate` → `reg.DecodeUpdate` (the `ordersapp.UpdateOrder` decoder) | `executeSingleOperation` normal update path (`formdataapp.go:320-377`) — caller submits JSON whose keys must match `ordersapp.UpdateOrder` | `executeUpdate` at `formdataapp.go:457-488`, which calls `reg.DecodeUpdate(data)` | MEDIUM — if `ordersapp.UpdateOrder` renames a field (`total` → `total_amount`) or adds a required field, the hand-rolled map silently supplies the wrong key set; decoder ignores unknown keys, so this fails silently | UNGUARDED — no dedicated tests for `recalculateOrderTotalsIfNeeded`; no integration test asserts `total_amount` appears in the DB after upsert |
+| 3 | `workflow.TemplateProcessor.ProcessTemplateObject` (`template.go:155`) — full engine (filters, `$me`/`$now` builtins, dot-notation, `{{expr:...}}`) | `resolveTemplateVars` (`communication/alert.go:230-243`) — 12-line private regex used in email, notification, alert action handlers; supports only flat `{{key}}` | Both consume templates written by the same form-field authors | MEDIUM — expressions with dot-notation, filters, or `$me`/`$now` silently left unresolved (returned as literal `{{...}}`) in email/notification/alert bodies, while the same template processes correctly during form-data upsert | PARTIALLY GUARDED — `email_test.go` and `notification_test.go` test flat substitution; no tests exercise dot-notation or `$me` in these handlers |
+
+**Summary.** Finding 1 is the highest-severity because `FieldDefaultConfig` and `LineItemField` are already *explicitly* documented as sharing the same fields ("same fields as `FieldDefaultConfig` for consistency" — `model.go:210-214`), yet the extraction logic is duplicated. Finding 2 is a classic "side-door update" twin — works today, falls over the moment `UpdateOrder` evolves. Finding 3 is the most subtle: two template engines in the same project with different grammars is a drift-factory.
+
+**Checked and cleared.**
+- `formdataregistry.EntityRegistration` — named-struct contract; no bare `map[string]any` at the registry boundary.
+- `TemplateProcessor` call site inside `formdataapp` — exactly one call site (`formdataapp.go:335`); no second path within the form-data pipeline.
+- `buildExecutionPlan` / `executeOperation` ordering — single deterministic code path.
+- `ActionExecutionContext` construction — three sites, all populate `RawData` from upstream; no template-relevant field differs.
+- Registry thread-safety — `RWMutex`-guarded, read-only post-startup.
+
+---
+
+## Cross-surface observations
+
+- **`seek_approval` is the single highest-risk handler in the codebase.** It appears in surfaces 2, 3, and 4 with three different twin-site patterns (sync-vs-async completion shape, stub-vs-real Execute branches, and a missing WebSocket publish). Fixing this one handler would close 4 findings.
+- **`approvalapi`'s WebSocket publisher (`publishApprovalResolved`) is a PR #126 repeat.** Same shape of bug (inline map + distant consumer keyed by convention), just on the RabbitMQ/WS channel instead of the Temporal channel.
+- **The canonical fix pattern (typed struct / named helper) is already in use in many places** — `buildResolveResult`, `buildWebhookResult`, the `ActionXxxData` delegate helpers, the `toApp*` HTTP encoders. The twin-site risks above are all "someone forgot to use the helper" cases, not "no helper exists" cases.
+- **Tests assert shape at the primary site, not at secondary sites or cross-site.** The universal test-hygiene gap: a single-site `ExpResp` check is not a parity check.
+
+## Suspicious but safe (catalogued so the next auditor doesn't re-check)
+
+- `approvalapi.completeAndClear` + `retryTemporalCompletion` — shared `buildResolveResult()` since PR #126; deeply guarded.
+- `ExecuteActionActivity` / `ExecuteAsyncActionActivity` — both single-writer.
+- `AsyncCompleter.Complete/Fail` — thin delegation, no payload drift possible.
+- ~68 registered delegate domains (ordersbus, userbus, etc.) — all conform to standard `ActionXxxParms` shape with `ActionXxxData` helpers.
+- Inventory CRUD HTTP surface (`transferorderapi`, `putawaytaskapi`, `picktaskapi`, `cyclecountitemapi`, `cyclecountsessionapi`) — straight passthrough.
+- Procurement/sales/floor HTTP handlers — return app-layer result directly, no inline twin.
+- `call_webhook`, `transition_status`, `update_field`, `log_audit_entry`, `create_entity`, `lookup_entity` action handlers — single-writer skeletons.
+- `formdataregistry` — named-struct contract at the boundary.
+- WebSocket hub broadcast targeting — deterministic, no drift surface.
+- `alert_updated` and `create_alert` pipelines — single-writer end-to-end.
+
+---
+
+*Audit complete. No code changes made.*


### PR DESCRIPTION
## Summary

- Fixes three HIGH-severity variants of the PR #126 bug shape (two inline `map[string]any` literals feed one consumer by string key, no parity):
  1. **approvalapi.publishApprovalResolved routing** — consumer falls through to default `"alert"` branch because `"approval_resolved"` had no explicit case; frontend `"alert"` subscribers receive a foreign key set (`approvalId` instead of `id`, etc.).
  2. **seek_approval WebSocket publish gap** — approval-request alerts were persisted to DB but never broadcast; approvers had no real-time notification.
  3. **alertapi.testAlert divergent shapes** — the handler returned a 14-field canonical alert to the HTTP caller but hand-rolled a 9-field map for the WebSocket push.
- Structural fix: extract `BuildAlertPayload` + `PublishAlertToRecipients` + `messageTypeForAlert` + `buildApprovalResolvedPayload` as shared seams so future sites can't drift; `CreateAlertHandler.publishAlertToWebSocket` collapses to a one-liner.
- Docs: terse twin-site callout in `docs/arch/domain-template.md` listing existing shared builders. Full audit at `tasks/twin-site-audit.md` (7 surfaces, 19 candidates, this PR tackles the top 3).

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet` on all packages touching `seek_approval` — clean
- [x] `go test -count=1` on foundation/websocket, alertws (integration consumer with RabbitMQ), approvalapi, communication, approval (full `seek_test.go` DB suite) — all green
- [x] 11 new unit tests cover every extracted helper + parity rules
- [ ] Smoke: approve a workflow in staging, confirm frontend receives `approval_resolved` WS frame with correct payload shape
- [ ] Smoke: trigger a `seek_approval` action, confirm approver's browser shows the alert in real time (previously required REST poll)
- [ ] Smoke: POST `/v1/workflow/alerts/test`, confirm WS payload carries all 14 canonical alert fields

## Related

- Motivating PR: #126 (same bug shape, Temporal Result payload)
- Full audit: `tasks/twin-site-audit.md`

> **Note on the relationship to #126:** this PR does not modify anything introduced by #126 — the two are structurally parallel, not sequential. #126 fixed one twin-site bug in approvalapi's Temporal retry path; #127 fixes three *different* twin-site bugs in unrelated files, discovered by auditing the codebase for the same pattern. No file overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
