### PR TITLE
phase-0g.B4 (PR B): seed expansion (40 products, 79 labels, zoned reporters)

### DIFF
--- a/business/domain/products/productbus/testutil.go
+++ b/business/domain/products/productbus/testutil.go
@@ -134,7 +134,8 @@ func TestNewProductsHistorical(n int, daysBack int, brandIDs, productCategoryIDs
 // TestSeedProductsHistoricalWithDistribution generates n products with the
 // caller-provided tracking-type distribution. distribution must have len == n;
 // each entry must be one of "none", "lot", "serial". Pass nil to fall back to
-// the modulo-based default ({"none","lot","serial"}[i%len(defaultTypes)]).
+// the modulo-based default that TestNewProductsHistorical applies via
+// {"none","lot","serial"}[i%len(trackingTypes)].
 func TestSeedProductsHistoricalWithDistribution(
 	ctx context.Context,
 	n int,

--- a/business/domain/products/productbus/testutil.go
+++ b/business/domain/products/productbus/testutil.go
@@ -134,7 +134,7 @@ func TestNewProductsHistorical(n int, daysBack int, brandIDs, productCategoryIDs
 // TestSeedProductsHistoricalWithDistribution generates n products with the
 // caller-provided tracking-type distribution. distribution must have len == n;
 // each entry must be one of "none", "lot", "serial". Pass nil to fall back to
-// the modulo-based default ({"none","lot","serial"}[i%3]).
+// the modulo-based default ({"none","lot","serial"}[i%len(defaultTypes)]).
 func TestSeedProductsHistoricalWithDistribution(
 	ctx context.Context,
 	n int,
@@ -147,54 +147,17 @@ func TestSeedProductsHistoricalWithDistribution(
 		return nil, fmt.Errorf("distribution length %d != n %d", len(distribution), n)
 	}
 
-	now := time.Now()
-	productNames := []string{
-		"Industrial Bearing 6205",
-		"Nitrile Gloves Box/100",
-		"Hydraulic Filter HF-302",
-		"LED Panel Light 60W",
-		"Stainless Steel Bolt M10",
-		"Thermal Paste Tube 5g",
-		"Safety Goggles Clear",
-		"Rubber Gasket Set",
-		"Wire Spool CAT6 100m",
-		"Epoxy Adhesive 2-Part",
+	newProducts := TestNewProductsHistorical(n, daysBack, brandIDs, productCategoryIDs)
+	if distribution != nil {
+		for i := range newProducts {
+			newProducts[i].TrackingType = distribution[i]
+			newProducts[i].IsPerishable = distribution[i] == "lot"
+		}
 	}
 
-	defaultTypes := []string{"none", "lot", "serial"}
-	idx := rand.Intn(10000)
 	products := make([]Product, 0, n)
-
-	for i := 0; i < n; i++ {
-		idx++
-
-		daysAgo := (i * daysBack) / n
-		createdDate := now.AddDate(0, 0, -daysAgo)
-
-		var trackingType string
-		if distribution != nil {
-			trackingType = distribution[i]
-		} else {
-			trackingType = defaultTypes[i%len(defaultTypes)]
-		}
-
-		nu := NewProduct{
-			Name:                 productNames[i%len(productNames)],
-			BrandID:              brandIDs[rand.Intn(len(brandIDs))],
-			ProductCategoryID:    productCategoryIDs[rand.Intn(len(productCategoryIDs))],
-			Description:          fmt.Sprintf("High-quality %s for warehouse operations", productNames[i%len(productNames)]),
-			SKU:                  fmt.Sprintf("SKU-%04d", i+1),
-			ModelNumber:          fmt.Sprintf("MDL-%04d", i+1),
-			UpcCode:              fmt.Sprintf("0123456789%02d", i%100),
-			Status:               "active",
-			IsActive:             idx%2 == 0,
-			IsPerishable:         trackingType == "lot",
-			HandlingInstructions: fmt.Sprintf("Handling instructions %d", idx),
-			UnitsPerCase:         idx * 5,
-			TrackingType:         trackingType,
-			CreatedDate:          &createdDate,
-		}
-		p, err := api.Create(ctx, nu)
+	for i, np := range newProducts {
+		p, err := api.Create(ctx, np)
 		if err != nil {
 			return nil, fmt.Errorf("create product %d: %w", i, err)
 		}

--- a/business/domain/products/productbus/testutil.go
+++ b/business/domain/products/productbus/testutil.go
@@ -131,18 +131,74 @@ func TestNewProductsHistorical(n int, daysBack int, brandIDs, productCategoryIDs
 	return newProducts
 }
 
-// TestSeedProductsHistorical seeds products with historical date distribution.
-func TestSeedProductsHistorical(ctx context.Context, n int, daysBack int, brandIDs, productCategoryIDs uuid.UUIDs, api *Business) ([]Product, error) {
-	newProducts := TestNewProductsHistorical(n, daysBack, brandIDs, productCategoryIDs)
+// TestSeedProductsHistoricalWithDistribution generates n products with the
+// caller-provided tracking-type distribution. distribution must have len == n;
+// each entry must be one of "none", "lot", "serial". Pass nil to fall back to
+// the modulo-based default ({"none","lot","serial"}[i%3]).
+func TestSeedProductsHistoricalWithDistribution(
+	ctx context.Context,
+	n int,
+	daysBack int,
+	distribution []string,
+	brandIDs, productCategoryIDs uuid.UUIDs,
+	api *Business,
+) ([]Product, error) {
+	if distribution != nil && len(distribution) != n {
+		return nil, fmt.Errorf("distribution length %d != n %d", len(distribution), n)
+	}
 
-	products := make([]Product, len(newProducts))
+	now := time.Now()
+	productNames := []string{
+		"Industrial Bearing 6205",
+		"Nitrile Gloves Box/100",
+		"Hydraulic Filter HF-302",
+		"LED Panel Light 60W",
+		"Stainless Steel Bolt M10",
+		"Thermal Paste Tube 5g",
+		"Safety Goggles Clear",
+		"Rubber Gasket Set",
+		"Wire Spool CAT6 100m",
+		"Epoxy Adhesive 2-Part",
+	}
 
-	for i, np := range newProducts {
-		product, err := api.Create(ctx, np)
-		if err != nil {
-			return nil, err
+	defaultTypes := []string{"none", "lot", "serial"}
+	idx := rand.Intn(10000)
+	products := make([]Product, 0, n)
+
+	for i := 0; i < n; i++ {
+		idx++
+
+		daysAgo := (i * daysBack) / n
+		createdDate := now.AddDate(0, 0, -daysAgo)
+
+		var trackingType string
+		if distribution != nil {
+			trackingType = distribution[i]
+		} else {
+			trackingType = defaultTypes[i%len(defaultTypes)]
 		}
-		products[i] = product
+
+		nu := NewProduct{
+			Name:                 productNames[i%len(productNames)],
+			BrandID:              brandIDs[rand.Intn(len(brandIDs))],
+			ProductCategoryID:    productCategoryIDs[rand.Intn(len(productCategoryIDs))],
+			Description:          fmt.Sprintf("High-quality %s for warehouse operations", productNames[i%len(productNames)]),
+			SKU:                  fmt.Sprintf("SKU-%04d", i+1),
+			ModelNumber:          fmt.Sprintf("MDL-%04d", i+1),
+			UpcCode:              fmt.Sprintf("0123456789%02d", i%100),
+			Status:               "active",
+			IsActive:             idx%2 == 0,
+			IsPerishable:         trackingType == "lot",
+			HandlingInstructions: fmt.Sprintf("Handling instructions %d", idx),
+			UnitsPerCase:         idx * 5,
+			TrackingType:         trackingType,
+			CreatedDate:          &createdDate,
+		}
+		p, err := api.Create(ctx, nu)
+		if err != nil {
+			return nil, fmt.Errorf("create product %d: %w", i, err)
+		}
+		products = append(products, p)
 	}
 
 	sort.Slice(products, func(i, j int) bool {
@@ -153,4 +209,9 @@ func TestSeedProductsHistorical(ctx context.Context, n int, daysBack int, brandI
 	})
 
 	return products, nil
+}
+
+// TestSeedProductsHistorical seeds products with historical date distribution.
+func TestSeedProductsHistorical(ctx context.Context, n int, daysBack int, brandIDs, productCategoryIDs uuid.UUIDs, api *Business) ([]Product, error) {
+	return TestSeedProductsHistoricalWithDistribution(ctx, n, daysBack, nil, brandIDs, productCategoryIDs, api)
 }

--- a/business/domain/products/productbus/testutil.go
+++ b/business/domain/products/productbus/testutil.go
@@ -3,7 +3,6 @@ package productbus
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"sort"
 	"time"
 
@@ -28,7 +27,7 @@ func TestNewProducts(n int, brandIDs, productCategoryIDs uuid.UUIDs) []NewProduc
 
 	trackingTypes := []string{"none", "lot", "serial"}
 
-	idx := rand.Intn(10000)
+	idx := 0
 	for i := 0; i < n; i++ {
 		idx++
 
@@ -36,8 +35,8 @@ func TestNewProducts(n int, brandIDs, productCategoryIDs uuid.UUIDs) []NewProduc
 
 		np := NewProduct{
 			Name:                 productNames[i%len(productNames)],
-			BrandID:              brandIDs[rand.Intn(len(brandIDs))],
-			ProductCategoryID:    productCategoryIDs[rand.Intn(len(productCategoryIDs))],
+			BrandID:              brandIDs[i%len(brandIDs)],
+			ProductCategoryID:    productCategoryIDs[i%len(productCategoryIDs)],
 			Description:          fmt.Sprintf("High-quality %s for warehouse operations", productNames[i%len(productNames)]),
 			SKU:                  fmt.Sprintf("SKU-%04d", i+1),
 			ModelNumber:          fmt.Sprintf("MDL-%04d", i+1),
@@ -100,7 +99,7 @@ func TestNewProductsHistorical(n int, daysBack int, brandIDs, productCategoryIDs
 
 	trackingTypes := []string{"none", "lot", "serial"}
 
-	idx := rand.Intn(10000)
+	idx := 0
 	for i := 0; i < n; i++ {
 		idx++
 
@@ -111,8 +110,8 @@ func TestNewProductsHistorical(n int, daysBack int, brandIDs, productCategoryIDs
 
 		np := NewProduct{
 			Name:                 productNames[i%len(productNames)],
-			BrandID:              brandIDs[rand.Intn(len(brandIDs))],
-			ProductCategoryID:    productCategoryIDs[rand.Intn(len(productCategoryIDs))],
+			BrandID:              brandIDs[i%len(brandIDs)],
+			ProductCategoryID:    productCategoryIDs[i%len(productCategoryIDs)],
 			Description:          fmt.Sprintf("High-quality %s for warehouse operations", productNames[i%len(productNames)]),
 			SKU:                  fmt.Sprintf("SKU-%04d", i+1),
 			ModelNumber:          fmt.Sprintf("MDL-%04d", i+1),
@@ -173,9 +172,4 @@ func TestSeedProductsHistoricalWithDistribution(
 	})
 
 	return products, nil
-}
-
-// TestSeedProductsHistorical seeds products with historical date distribution.
-func TestSeedProductsHistorical(ctx context.Context, n int, daysBack int, brandIDs, productCategoryIDs uuid.UUIDs, api *Business) ([]Product, error) {
-	return TestSeedProductsHistoricalWithDistribution(ctx, n, daysBack, nil, brandIDs, productCategoryIDs, api)
 }

--- a/business/sdk/dbtest/seedFrontend.go
+++ b/business/sdk/dbtest/seedFrontend.go
@@ -54,13 +54,13 @@ func InsertSeedData(log *logger.Logger, cfg sqldb.Config) error {
 		return fmt.Errorf("seeding assets: %w", err)
 	}
 
-	if err := seedLabels(ctx, busDomain.Label); err != nil {
-		return fmt.Errorf("seed labels: %w", err)
-	}
-
 	products, err := seedProducts(ctx, busDomain, geoHR, foundation)
 	if err != nil {
 		return fmt.Errorf("seeding products: %w", err)
+	}
+
+	if err := seedLabels(ctx, busDomain.Label, products); err != nil {
+		return fmt.Errorf("seed labels: %w", err)
 	}
 
 	inventory, err := seedInventory(ctx, busDomain, foundation, geoHR, products)

--- a/business/sdk/dbtest/seedFrontend.go
+++ b/business/sdk/dbtest/seedFrontend.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
 	"github.com/timmaaaz/ichor/business/sdk/sqldb"
 	"github.com/timmaaaz/ichor/foundation/logger"
 )
@@ -19,6 +20,14 @@ func InsertSeedData(log *logger.Logger, cfg sqldb.Config) error {
 		return fmt.Errorf("connect database: %w", err)
 	}
 	defer db.Close()
+	return InsertSeedDataWithDB(log, db)
+}
+
+// InsertSeedDataWithDB runs the full Phase-0g seed chain against an
+// already-open database connection. Used by the CLI seedFrontend command (via
+// InsertSeedData) and by integration tests that wire seeding into a
+// dbtest.NewDatabase fixture.
+func InsertSeedDataWithDB(log *logger.Logger, db *sqlx.DB) error {
 	busDomain := newBusDomains(log, db)
 
 	ctx := context.Background()

--- a/business/sdk/dbtest/seed_foundation.go
+++ b/business/sdk/dbtest/seed_foundation.go
@@ -40,22 +40,21 @@ func seedFoundation(ctx context.Context, busDomain BusDomain) (FoundationSeed, e
 	}
 
 	// Assign warehouse zones to 2 reporters for zone-sliced multi-worker pick
-	// coverage (Phase 0g.B4). reporters[0] gets STG-A/STG-B; reporters[1] gets
-	// STG-C/PCK. Other reporters keep the empty default.
-	if len(reporters) >= 2 {
-		zonesA := []string{"STG-A", "STG-B"}
-		zonesB := []string{"STG-C", "PCK"}
-		updated0, err := busDomain.User.Update(ctx, reporters[0], userbus.UpdateUser{AssignedZones: &zonesA})
-		if err != nil {
-			return FoundationSeed{}, fmt.Errorf("assign zones to reporter[0]: %w", err)
-		}
-		reporters[0] = updated0
-		updated1, err := busDomain.User.Update(ctx, reporters[1], userbus.UpdateUser{AssignedZones: &zonesB})
-		if err != nil {
-			return FoundationSeed{}, fmt.Errorf("assign zones to reporter[1]: %w", err)
-		}
-		reporters[1] = updated1
+	// coverage. reporters[0] gets STG-A/STG-B; reporters[1] gets STG-C/PCK.
+	// Other reporters keep the empty default. Failures here surface loudly:
+	// a missing reporters[0]/[1] panics rather than silently skipping.
+	zonesA := []string{"STG-A", "STG-B"}
+	zonesB := []string{"STG-C", "PCK"}
+	updated0, err := busDomain.User.Update(ctx, reporters[0], userbus.UpdateUser{AssignedZones: &zonesA})
+	if err != nil {
+		return FoundationSeed{}, fmt.Errorf("assign zones to reporter[0]: %w", err)
 	}
+	reporters[0] = updated0
+	updated1, err := busDomain.User.Update(ctx, reporters[1], userbus.UpdateUser{AssignedZones: &zonesB})
+	if err != nil {
+		return FoundationSeed{}, fmt.Errorf("assign zones to reporter[1]: %w", err)
+	}
+	reporters[1] = updated1
 
 	bosses, err := userbus.TestSeedUsersWithNoFKs(ctx, 10, userbus.Roles.User, busDomain.User)
 	if err != nil {

--- a/business/sdk/dbtest/seed_foundation.go
+++ b/business/sdk/dbtest/seed_foundation.go
@@ -39,6 +39,24 @@ func seedFoundation(ctx context.Context, busDomain BusDomain) (FoundationSeed, e
 		reporterIDs[i] = r.ID
 	}
 
+	// Assign warehouse zones to 2 reporters for zone-sliced multi-worker pick
+	// coverage (Phase 0g.B4). reporters[0] gets STG-A/STG-B; reporters[1] gets
+	// STG-C/PCK. Other reporters keep the empty default.
+	if len(reporters) >= 2 {
+		zonesA := []string{"STG-A", "STG-B"}
+		zonesB := []string{"STG-C", "PCK"}
+		updated0, err := busDomain.User.Update(ctx, reporters[0], userbus.UpdateUser{AssignedZones: &zonesA})
+		if err != nil {
+			return FoundationSeed{}, fmt.Errorf("assign zones to reporter[0]: %w", err)
+		}
+		reporters[0] = updated0
+		updated1, err := busDomain.User.Update(ctx, reporters[1], userbus.UpdateUser{AssignedZones: &zonesB})
+		if err != nil {
+			return FoundationSeed{}, fmt.Errorf("assign zones to reporter[1]: %w", err)
+		}
+		reporters[1] = updated1
+	}
+
 	bosses, err := userbus.TestSeedUsersWithNoFKs(ctx, 10, userbus.Roles.User, busDomain.User)
 	if err != nil {
 		return FoundationSeed{}, fmt.Errorf("seeding reporter : %w", err)

--- a/business/sdk/dbtest/seed_integration_test.go
+++ b/business/sdk/dbtest/seed_integration_test.go
@@ -1,0 +1,85 @@
+package dbtest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/timmaaaz/ichor/business/domain/labels/labelbus"
+	"github.com/timmaaaz/ichor/business/domain/products/productbus"
+	"github.com/timmaaaz/ichor/business/sdk/page"
+)
+
+// Test_Seed_Integration runs the full Phase 0g.B4 seed chain against a fresh
+// dbtest database and asserts the post-seed shape:
+//   - 79 label rows (19 location + 20 container + 40 product)
+//   - 40 products with tracking distribution {28 none, 8 lot, 4 serial}
+//   - ≥1 user with assigned_zones containing "STG-A"
+//   - ≥1 user with assigned_zones containing "STG-C"
+func Test_Seed_Integration(t *testing.T) {
+	t.Parallel()
+
+	db := NewDatabase(t, "Test_Seed_Integration")
+
+	if err := InsertSeedDataWithDB(db.Log, db.DB); err != nil {
+		t.Fatalf("InsertSeedDataWithDB: %v", err)
+	}
+
+	ctx := context.Background()
+
+	// --- 79 labels split 19 / 20 / 40 across types -----------------------
+	pg := page.MustParse("1", "200")
+	labels, err := db.BusDomain.Label.Query(ctx, labelbus.QueryFilter{}, labelbus.DefaultOrderBy, pg)
+	if err != nil {
+		t.Fatalf("label query: %v", err)
+	}
+	if got, want := len(labels), 79; got != want {
+		t.Fatalf("label count: got %d, want %d", got, want)
+	}
+	typeCounts := map[string]int{}
+	for _, l := range labels {
+		typeCounts[l.Type]++
+	}
+	for typ, want := range map[string]int{
+		labelbus.TypeLocation:  19,
+		labelbus.TypeContainer: 20,
+		labelbus.TypeProduct:   40,
+	} {
+		if got := typeCounts[typ]; got != want {
+			t.Errorf("label type %q count: got %d, want %d", typ, got, want)
+		}
+	}
+
+	// --- 40 products with 28/8/4 tracking distribution -------------------
+	products, err := db.BusDomain.Product.Query(ctx, productbus.QueryFilter{}, productbus.DefaultOrderBy, pg)
+	if err != nil {
+		t.Fatalf("product query: %v", err)
+	}
+	if got, want := len(products), 40; got != want {
+		t.Fatalf("product count: got %d, want %d", got, want)
+	}
+	trackCounts := map[string]int{}
+	for _, p := range products {
+		trackCounts[p.TrackingType]++
+	}
+	for typ, want := range map[string]int{"none": 28, "lot": 8, "serial": 4} {
+		if got := trackCounts[typ]; got != want {
+			t.Errorf("tracking %q count: got %d, want %d", typ, got, want)
+		}
+	}
+
+	// --- ≥1 user in STG-A and ≥1 user in STG-C ---------------------------
+	zonedA, err := db.BusDomain.User.QueryByAssignedZone(ctx, "STG-A")
+	if err != nil {
+		t.Fatalf("query STG-A: %v", err)
+	}
+	if len(zonedA) < 1 {
+		t.Errorf("expected ≥1 user assigned to STG-A, got %d", len(zonedA))
+	}
+	zonedC, err := db.BusDomain.User.QueryByAssignedZone(ctx, "STG-C")
+	if err != nil {
+		t.Fatalf("query STG-C: %v", err)
+	}
+	if len(zonedC) < 1 {
+		t.Errorf("expected ≥1 user assigned to STG-C, got %d", len(zonedC))
+	}
+}

--- a/business/sdk/dbtest/seed_integration_test.go
+++ b/business/sdk/dbtest/seed_integration_test.go
@@ -26,42 +26,54 @@ func Test_Seed_Integration(t *testing.T) {
 
 	ctx := context.Background()
 
-	// --- 79 labels split 19 / 20 / 40 across types -----------------------
+	// --- labels split across types --------------------------------------
+	expectedLabelsByType := map[string]int{
+		labelbus.TypeLocation:  19,
+		labelbus.TypeContainer: 20,
+		labelbus.TypeProduct:   40,
+	}
+	expectedLabelTotal := 0
+	for _, n := range expectedLabelsByType {
+		expectedLabelTotal += n
+	}
+
 	pg := page.MustParse("1", "200")
 	labels, err := db.BusDomain.Label.Query(ctx, labelbus.QueryFilter{}, labelbus.DefaultOrderBy, pg)
 	if err != nil {
 		t.Fatalf("label query: %v", err)
 	}
-	if got, want := len(labels), 79; got != want {
-		t.Fatalf("label count: got %d, want %d", got, want)
+	if got := len(labels); got != expectedLabelTotal {
+		t.Fatalf("label count: got %d, want %d", got, expectedLabelTotal)
 	}
 	typeCounts := map[string]int{}
 	for _, l := range labels {
 		typeCounts[l.Type]++
 	}
-	for typ, want := range map[string]int{
-		labelbus.TypeLocation:  19,
-		labelbus.TypeContainer: 20,
-		labelbus.TypeProduct:   40,
-	} {
+	for typ, want := range expectedLabelsByType {
 		if got := typeCounts[typ]; got != want {
 			t.Errorf("label type %q count: got %d, want %d", typ, got, want)
 		}
 	}
 
-	// --- 40 products with 28/8/4 tracking distribution -------------------
+	// --- products with tracking distribution ----------------------------
+	expectedProductsByTracking := map[string]int{"none": 28, "lot": 8, "serial": 4}
+	expectedProductTotal := 0
+	for _, n := range expectedProductsByTracking {
+		expectedProductTotal += n
+	}
+
 	products, err := db.BusDomain.Product.Query(ctx, productbus.QueryFilter{}, productbus.DefaultOrderBy, pg)
 	if err != nil {
 		t.Fatalf("product query: %v", err)
 	}
-	if got, want := len(products), 40; got != want {
-		t.Fatalf("product count: got %d, want %d", got, want)
+	if got := len(products); got != expectedProductTotal {
+		t.Fatalf("product count: got %d, want %d", got, expectedProductTotal)
 	}
 	trackCounts := map[string]int{}
 	for _, p := range products {
 		trackCounts[p.TrackingType]++
 	}
-	for typ, want := range map[string]int{"none": 28, "lot": 8, "serial": 4} {
+	for typ, want := range expectedProductsByTracking {
 		if got := trackCounts[typ]; got != want {
 			t.Errorf("tracking %q count: got %d, want %d", typ, got, want)
 		}

--- a/business/sdk/dbtest/seed_labels.go
+++ b/business/sdk/dbtest/seed_labels.go
@@ -2,6 +2,7 @@ package dbtest
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/google/uuid"
@@ -18,36 +19,78 @@ func detUUID(key string) uuid.UUID {
 	return uuid.NewSHA1(detNamespace, []byte(key))
 }
 
-// seedLabels inserts the 39-label Phase 1 catalog (19 locations + 20 containers)
-// with deterministic UUIDs. Matches spec §3.3.
-func seedLabels(ctx context.Context, bus *labelbus.Business) error {
-	entries := []struct {
-		code, typ string
-	}{
-		{"RCV-01", labelbus.TypeLocation}, {"RCV-02", labelbus.TypeLocation},
-		{"QA-01", labelbus.TypeLocation},
-		{"STG-A01", labelbus.TypeLocation}, {"STG-A02", labelbus.TypeLocation}, {"STG-A03", labelbus.TypeLocation},
-		{"STG-B01", labelbus.TypeLocation}, {"STG-B02", labelbus.TypeLocation}, {"STG-B03", labelbus.TypeLocation},
-		{"STG-C01", labelbus.TypeLocation}, {"STG-C02", labelbus.TypeLocation}, {"STG-C03", labelbus.TypeLocation},
-		{"PCK-01", labelbus.TypeLocation}, {"PCK-02", labelbus.TypeLocation}, {"PCK-03", labelbus.TypeLocation},
-		{"PKG-01", labelbus.TypeLocation}, {"PKG-02", labelbus.TypeLocation},
-		{"SHP-01", labelbus.TypeLocation}, {"SHP-02", labelbus.TypeLocation},
+// seedLabels inserts the 79-label Phase 0g.B4 catalog (19 locations + 20
+// containers + 40 product labels) with deterministic UUIDs. Matches spec §3.3.
+func seedLabels(ctx context.Context, bus *labelbus.Business, products ProductsSeed) error {
+	type entry struct {
+		code        string
+		typ         string
+		entityRef   string
+		payloadJSON string
 	}
+
+	entries := []entry{
+		{code: "RCV-01", typ: labelbus.TypeLocation, payloadJSON: "{}"},
+		{code: "RCV-02", typ: labelbus.TypeLocation, payloadJSON: "{}"},
+		{code: "QA-01", typ: labelbus.TypeLocation, payloadJSON: "{}"},
+		{code: "STG-A01", typ: labelbus.TypeLocation, payloadJSON: "{}"},
+		{code: "STG-A02", typ: labelbus.TypeLocation, payloadJSON: "{}"},
+		{code: "STG-A03", typ: labelbus.TypeLocation, payloadJSON: "{}"},
+		{code: "STG-B01", typ: labelbus.TypeLocation, payloadJSON: "{}"},
+		{code: "STG-B02", typ: labelbus.TypeLocation, payloadJSON: "{}"},
+		{code: "STG-B03", typ: labelbus.TypeLocation, payloadJSON: "{}"},
+		{code: "STG-C01", typ: labelbus.TypeLocation, payloadJSON: "{}"},
+		{code: "STG-C02", typ: labelbus.TypeLocation, payloadJSON: "{}"},
+		{code: "STG-C03", typ: labelbus.TypeLocation, payloadJSON: "{}"},
+		{code: "PCK-01", typ: labelbus.TypeLocation, payloadJSON: "{}"},
+		{code: "PCK-02", typ: labelbus.TypeLocation, payloadJSON: "{}"},
+		{code: "PCK-03", typ: labelbus.TypeLocation, payloadJSON: "{}"},
+		{code: "PKG-01", typ: labelbus.TypeLocation, payloadJSON: "{}"},
+		{code: "PKG-02", typ: labelbus.TypeLocation, payloadJSON: "{}"},
+		{code: "SHP-01", typ: labelbus.TypeLocation, payloadJSON: "{}"},
+		{code: "SHP-02", typ: labelbus.TypeLocation, payloadJSON: "{}"},
+	}
+
+	// 20 deterministic container/tote labels.
 	for i := 1; i <= 20; i++ {
-		entries = append(entries, struct{ code, typ string }{
-			code: fmt.Sprintf("TOTE-%03d", i),
-			typ:  labelbus.TypeContainer,
+		entries = append(entries, entry{
+			code:        fmt.Sprintf("TOTE-%03d", i),
+			typ:         labelbus.TypeContainer,
+			payloadJSON: "{}",
 		})
 	}
-	if len(entries) != 39 {
-		return fmt.Errorf("expected 39 seed entries, got %d", len(entries))
+
+	// 40 product labels — one per seeded product, with the product UUID as
+	// entity_ref and a JSON payload carrying SKU/UPC/name for label rendering.
+	for _, p := range products.Products {
+		payload, err := json.Marshal(struct {
+			SKU         string `json:"sku"`
+			UPC         string `json:"upc"`
+			ProductName string `json:"productName"`
+		}{SKU: p.SKU, UPC: p.UpcCode, ProductName: p.Name})
+		if err != nil {
+			return fmt.Errorf("marshal product label payload for %s: %w", p.SKU, err)
+		}
+		entries = append(entries, entry{
+			code:        fmt.Sprintf("PRD-%s", p.SKU),
+			typ:         labelbus.TypeProduct,
+			entityRef:   p.ProductID.String(),
+			payloadJSON: string(payload),
+		})
 	}
+
+	const expectedTotal = 79
+	if len(entries) != expectedTotal {
+		return fmt.Errorf("expected %d seed entries, got %d", expectedTotal, len(entries))
+	}
+
 	for _, e := range entries {
 		lc := labelbus.LabelCatalog{
 			ID:          detUUID("label:" + e.code),
 			Code:        e.code,
 			Type:        e.typ,
-			PayloadJSON: "{}",
+			EntityRef:   e.entityRef,
+			PayloadJSON: e.payloadJSON,
 		}
 		if err := bus.SeedCreate(ctx, lc); err != nil {
 			return fmt.Errorf("seedcreate %s: %w", e.code, err)

--- a/business/sdk/dbtest/seed_labels.go
+++ b/business/sdk/dbtest/seed_labels.go
@@ -72,6 +72,8 @@ func seedLabels(ctx context.Context, bus *labelbus.Business, products ProductsSe
 			return fmt.Errorf("marshal product label payload for %s: %w", p.SKU, err)
 		}
 		entries = append(entries, entry{
+			// Code format depends on productbus.TestNewProductsHistorical's
+			// SKU-%04d pattern; if SKU format changes, label codes shift.
 			code:        fmt.Sprintf("PRD-%s", p.SKU),
 			typ:         labelbus.TypeProduct,
 			entityRef:   p.ProductID.String(),

--- a/business/sdk/dbtest/seed_products.go
+++ b/business/sdk/dbtest/seed_products.go
@@ -45,7 +45,24 @@ func seedProducts(ctx context.Context, busDomain BusDomain, geoHR GeographyHRSee
 		productCategoryIDs[i] = pc.ProductCategoryID
 	}
 
-	products, err := productbus.TestSeedProductsHistorical(ctx, 20, 180, brandIDs, productCategoryIDs, busDomain.Product)
+	const productCount = 40
+
+	// 28×"none" + 8×"lot" + 4×"serial" tracking-type distribution for the
+	// 40-product seed. Order is intentional and stable across reseeds.
+	distribution := make([]string, 0, productCount)
+	for i := 0; i < 28; i++ {
+		distribution = append(distribution, "none")
+	}
+	for i := 0; i < 8; i++ {
+		distribution = append(distribution, "lot")
+	}
+	for i := 0; i < 4; i++ {
+		distribution = append(distribution, "serial")
+	}
+
+	products, err := productbus.TestSeedProductsHistoricalWithDistribution(
+		ctx, productCount, 180, distribution, brandIDs, productCategoryIDs, busDomain.Product,
+	)
 	if err != nil {
 		return ProductsSeed{}, fmt.Errorf("seeding product : %w", err)
 	}
@@ -55,23 +72,23 @@ func seedProducts(ctx context.Context, busDomain BusDomain, geoHR GeographyHRSee
 	}
 
 	// All product costs use USD - single base currency for consistency
-	_, err = productcostbus.TestSeedProductCosts(ctx, 20, productIDs, uuid.UUIDs{foundation.USDCurrencyID}, busDomain.ProductCost)
+	_, err = productcostbus.TestSeedProductCosts(ctx, productCount, productIDs, uuid.UUIDs{foundation.USDCurrencyID}, busDomain.ProductCost)
 	if err != nil {
 		return ProductsSeed{}, fmt.Errorf("seeding product cost : %w", err)
 	}
 
-	_, err = physicalattributebus.TestSeedPhysicalAttributes(ctx, 20, productIDs, busDomain.PhysicalAttribute)
+	_, err = physicalattributebus.TestSeedPhysicalAttributes(ctx, productCount, productIDs, busDomain.PhysicalAttribute)
 	if err != nil {
 		return ProductsSeed{}, fmt.Errorf("seeding physical attribute : %w", err)
 	}
 
-	_, err = metricsbus.TestSeedMetrics(ctx, 40, productIDs, busDomain.Metrics)
+	_, err = metricsbus.TestSeedMetrics(ctx, 2*productCount, productIDs, busDomain.Metrics)
 	if err != nil {
 		return ProductsSeed{}, fmt.Errorf("seeding metrics : %w", err)
 	}
 
 	// Cost history also uses USD for consistency
-	_, err = costhistorybus.TestSeedCostHistoriesHistorical(ctx, 40, 180, productIDs, uuid.UUIDs{foundation.USDCurrencyID}, busDomain.CostHistory)
+	_, err = costhistorybus.TestSeedCostHistoriesHistorical(ctx, 2*productCount, 180, productIDs, uuid.UUIDs{foundation.USDCurrencyID}, busDomain.CostHistory)
 	if err != nil {
 		return ProductsSeed{}, fmt.Errorf("seeding cost history : %w", err)
 	}

--- a/docs/arch/seeding.md
+++ b/docs/arch/seeding.md
@@ -22,11 +22,12 @@ All values are randomized (names, IDs, dates). Only counts and relationships are
 | Offices | 10 | |
 | Brands | 5 | |
 | Product categories | 10 | |
-| Products | 20 | historical dates, 180-day window |
-| Product costs | 20 | all USD |
-| Physical attributes | 20 | |
-| Metrics | 40 | |
-| Cost history entries | 40 | historical, 180-day window |
+| Products | 40 | historical dates, 180-day window; tracking distribution 28 none / 8 lot / 4 serial |
+| Product costs | 40 | all USD |
+| Physical attributes | 40 | |
+| Metrics | 80 | |
+| Cost history entries | 80 | historical, 180-day window |
+| Label catalog | 79 | 19 location + 20 container + 40 product (one per seeded product) |
 | Warehouses | 5 | historical, 365-day window |
 | Zones | 12 | |
 | Inventory locations | 25 | |
@@ -254,7 +255,13 @@ file: business/sdk/dbtest/seedFrontend.go (~71 lines)
 
 ```go
 func InsertSeedData(log *logger.Logger, cfg sqldb.Config) error
+func InsertSeedDataWithDB(log *logger.Logger, db *sqlx.DB) error
 ```
+
+`InsertSeedData` opens a connection from `cfg`, defers Close, and delegates
+to `InsertSeedDataWithDB`. Integration tests (e.g. `Test_Seed_Integration`)
+call `InsertSeedDataWithDB` directly against the `dbtest.NewDatabase`-managed
+`*sqlx.DB` so the seed chain reuses the test container's connection.
 
 Dependency chain (execution order is authoritative — do not reorder):
 
@@ -265,7 +272,9 @@ seedGeographyHR(ctx, busDomain)                                 → GeographyHRS
     ↓
 seedAssets(ctx, busDomain, foundation)
     ↓
-seedProducts(ctx, busDomain, geoHR, foundation)                 → products result
+seedProducts(ctx, busDomain, geoHR, foundation)                 → ProductsSeed
+    ↓
+seedLabels(ctx, busDomain.Label, products)                      → 79 deterministic catalog rows
     ↓
 seedInventory(ctx, busDomain, foundation, geoHR, products)      → inventory result
     ↓
@@ -308,6 +317,9 @@ type FoundationSeed struct {
 func seedFoundation(ctx context.Context, busDomain BusDomain) (FoundationSeed, error)
 ```
 Seeds: users, roles, user roles, table access, currencies.
+After initial user seeding, `reporters[0]` is updated with `assigned_zones=["STG-A","STG-B"]`
+and `reporters[1]` with `assigned_zones=["STG-C","PCK"]` so picking can fan out to
+multiple zone-scoped workers in tests. Other reporters keep the empty default.
 
 ### seed_geography_hr.go
 ```go
@@ -331,7 +343,27 @@ Seeds: asset types, conditions, valid assets, assets, approval/fulfillment statu
 ```go
 func seedProducts(ctx context.Context, busDomain BusDomain, geoHR GeographyHRSeed, foundation FoundationSeed) (ProductsSeed, error)
 ```
-Seeds: brands, categories, products, costs, physical attributes, metrics, cost histories.
+Seeds: brands, categories, 40 products, costs, physical attributes, metrics, cost histories.
+Products use the `productbus.TestSeedProductsHistoricalWithDistribution` helper with an explicit
+28×`"none"` + 8×`"lot"` + 4×`"serial"` tracking-type distribution so downstream
+inventory/lot-tracking/serial-number seed logic has a stable shape to fan out from.
+
+### seed_labels.go
+```go
+func seedLabels(ctx context.Context, bus *labelbus.Business, products ProductsSeed) error
+```
+Seeds 79 rows: 19 location + 20 container + 40 product. Catalog UUIDs are deterministic
+via `detUUID("label:" + code)` (UUID v5 over the `deadbeef-…-beefdeadbeef` namespace) so
+`make reseed-frontend` produces byte-identical label IDs across runs.
+
+Type breakdown:
+- **Location** — RCV-NN, QA-NN, STG-{A|B|C}NN, PCK-NN, PKG-NN, SHP-NN. Empty `payload_json: "{}"`.
+- **Container** — TOTE-001..TOTE-020. Empty `payload_json: "{}"`.
+- **Product** — `PRD-{SKU}` (one per seeded product). `entity_ref` is the product UUID.
+  `payload_json` carries `{"sku":..., "upc":..., "productName":...}` for ZPL rendering.
+
+Note: product `entity_ref` is non-deterministic until `productbus.Business.SeedCreate` lands —
+all other label fields are stable across reseeds.
 
 ### seed_inventory.go
 ```go


### PR DESCRIPTION
## Summary

Second of two Tier B PRs (Tier A landed as #130). Grows the deterministic seed to match the Phase 0g.B4 spec §5.B4.

- **productbus testutil** — adds `TestSeedProductsHistoricalWithDistribution` for explicit per-index tracking-type distribution; existing `TestSeedProductsHistorical` becomes a thin nil-distribution delegate.
- **dbtest seeders** —
  - products 20→40 with explicit 28×none / 8×lot / 4×serial distribution
  - labels 39→79 (+40 product label rows with `type='product'`, `entity_ref=product UUID`, `payload_json={sku, upc, productName}`)
  - `assigned_zones=["STG-A","STG-B"]` and `["STG-C","PCK"]` set on first 2 reporters
  - small surgical refactor of `InsertSeedData` into a thin wrapper around new `InsertSeedDataWithDB` so integration tests can run the full seed chain against a `dbtest.NewDatabase` connection
- **dbtest integration test** — new `Test_Seed_Integration` asserts post-seed shape (79/19/20/40 labels, 40 products with 28/8/4 tracking, ≥1 user each in STG-A and STG-C). Test runs the full chain through Docker (~18s).

## Coordination

- Frontend companion (seed-ref.ts sync): https://github.com/timmaaaz/ichor-frontend/pull/93
- Depends on B1 (#128) for `labelbus.TypeContainer` + `labelbus.TypeProduct` — already on master.

## Tests

- \`go test ./business/domain/products/productbus/... -v\` — passes
- \`go test ./business/sdk/dbtest/... -v\` — passes (Test_Seed_Integration runs Docker)
- \`go build ./...\`, \`go vet ./...\`, \`gofmt -d\` all clean
- In-session \`superpowers:code-reviewer\` — APPROVED_WITH_NOTES (3 NITs, all explicitly non-blocking)

## Verified runtime invariants (T15 — local pgcli reseed-twice)

- 79 labels split: container=20, location=19, product=40 ✓
- 40 products split: lot=8, none=28, serial=4 ✓
- Two reporters with assigned_zones values \`STG-A,STG-B\` and \`STG-C,PCK\` ✓
- \`order_container_bindings\` empty (B5 will populate) ✓
- 39 location+container label rows byte-identical across two reseeds ✓

## Known limitation (carried forward, scoped out of B4)

\`productbus.Business.Create\` at \`productbus.go:86\` uses \`uuid.New()\` for ProductID. Consequence: \`inventory.label_catalog.entity_ref\` for \`type='product'\` rows drifts each reseed; same drift cascades to FK columns in inventory/sales/procurement. The T15 determinism check is therefore scoped to the deterministic subset (location+container labels + assigned_zones values + the empty bindings table). Productbus deterministic seeding is a B5 prerequisite and is tracked as a follow-up — likely shape: a \`productbus.Business.SeedCreate\` mirror of the existing \`labelbus.SeedCreate\` pattern, keyed on SKU.

## DoD

- [x] Migration 2.36 applies forward cleanly (verified in Tier A / #130)
- [x] \`make reseed-frontend\` produces correct counts; deterministic subset stable across reseeds
- [x] 40 products / 79 labels / 2 zone-assigned reporters present after seed
- [x] superpowers:code-reviewer passed in-session
- [ ] /code-review:code-review passed in fresh session (T20)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
