### PR TITLE
phase-0g.B5: config levers + scenario extensions

### DIFF
--- a/api/cmd/services/ichor/build/all/all.go
+++ b/api/cmd/services/ichor/build/all/all.go
@@ -678,7 +678,12 @@ func (a add) Add(app *web.App, cfg mux.Config) {
 	// middleware can wrap every route registered below. When cfg.ScenariosEnabled
 	// is false (prod default), the middleware is skipped entirely and scoped
 	// repositories' ctx-reads become no-ops.
-	scenarioBus := scenariobus.NewBusiness(cfg.Log, delegate, scenariodb.NewStore(cfg.Log, cfg.DB), sqldb.NewBeginner(cfg.DB))
+	scenariosRoot, scenariosRootErr := scenariobus.FindScenariosRoot()
+	if scenariosRootErr != nil {
+		cfg.Log.Error(context.Background(), "find scenarios root: worker-zone application disabled", "error", scenariosRootErr)
+		scenariosRoot = ""
+	}
+	scenarioBus := scenariobus.NewBusiness(cfg.Log, delegate, scenariodb.NewStore(cfg.Log, cfg.DB), sqldb.NewBeginner(cfg.DB), scenariosRoot)
 	if cfg.ScenariosEnabled {
 		app.Use(mid.ActiveScenario(scenarioBus))
 	}

--- a/api/cmd/services/ichor/build/all/all.go
+++ b/api/cmd/services/ichor/build/all/all.go
@@ -3,7 +3,9 @@ package all
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/timmaaaz/ichor/api/domain/http/agentapi/catalogapi"
@@ -678,7 +680,7 @@ func (a add) Add(app *web.App, cfg mux.Config) {
 	// middleware can wrap every route registered below. When cfg.ScenariosEnabled
 	// is false (prod default), the middleware is skipped entirely and scoped
 	// repositories' ctx-reads become no-ops.
-	scenariosRoot, scenariosRootErr := scenariobus.FindScenariosRoot()
+	scenariosRoot, scenariosRootErr := findScenariosRoot()
 	if scenariosRootErr != nil {
 		cfg.Log.Error(context.Background(), "find scenarios root: worker-zone application disabled", "error", scenariosRootErr)
 		scenariosRoot = ""
@@ -1640,4 +1642,25 @@ func (a add) Add(app *web.App, cfg mux.Config) {
 			"entities", len(formDataRegistry.ListEntities()))
 	}
 
+}
+
+// findScenariosRoot walks upward from cwd looking for go.mod and returns
+// <root>/deployments/scenarios. Returns an error in containerized prod
+// environments where go.mod is absent — callers should fall back to an
+// empty scenariosRoot, which disables worker-zone application during Load.
+func findScenariosRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("getwd: %w", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return filepath.Join(dir, "deployments", "scenarios"), nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("go.mod not found from %s upward", dir)
+		}
+		dir = parent
+	}
 }

--- a/api/cmd/services/ichor/tests/scenarios/scenarioapi/load_test.go
+++ b/api/cmd/services/ichor/tests/scenarios/scenarioapi/load_test.go
@@ -1,12 +1,14 @@
 package scenarioapi_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 	"github.com/timmaaaz/ichor/api/sdk/http/apitest"
+	"github.com/timmaaaz/ichor/app/domain/config/settingsapp"
 	"github.com/timmaaaz/ichor/app/sdk/errs"
 )
 
@@ -72,6 +74,56 @@ func load401(sd apitest.SeedData) []apitest.Table {
 			ExpResp:    errs.Newf(errs.Unauthenticated, "authorize: you are not authorized for that action, claims[[USER]] rule[rule_admin_only]: rego evaluation failed : bindings results[[{[true] map[x:false]}]] ok[true]"),
 			CmpFunc: func(got, exp any) string {
 				return cmp.Diff(got, exp)
+			},
+		},
+	}
+}
+
+// loadWithOverrides204 verifies the full HTTP pipeline for lever overrides:
+//   - POST /v1/scenarios/{id}/load → 204 (sets scenarios[1] as active, applies overrides)
+//   - GET /v1/config/settings/pick.lotScan → 200 with the merged override value
+//
+// scenarios[1] has a pre-seeded override "pick.lotScan" = "required-if-lot-tracked"
+// (inserted in seed_test.go). After Load, the settings query JOINs against the
+// active scenario and returns the override value instead of the lever default.
+func loadWithOverrides204(sd apitest.SeedData) []apitest.Table {
+	expValue, _ := json.Marshal("required-if-lot-tracked")
+
+	return []apitest.Table{
+		{
+			Name:       "load-scenario-with-overrides",
+			URL:        fmt.Sprintf("/v1/scenarios/%s/load", sd.Scenarios[1].ID),
+			Token:      sd.Admins[0].Token,
+			Method:     http.MethodPost,
+			StatusCode: http.StatusNoContent,
+			GotResp:    nil,
+			ExpResp:    nil,
+			CmpFunc:    func(_, _ any) string { return "" },
+		},
+		{
+			Name:       "get-settings-shows-merged-override",
+			URL:        "/v1/config/settings/pick.lotScan",
+			Token:      sd.Admins[0].Token,
+			Method:     http.MethodGet,
+			StatusCode: http.StatusOK,
+			GotResp:    &settingsapp.Setting{},
+			ExpResp:    &settingsapp.Setting{Key: "pick.lotScan", Value: json.RawMessage(expValue)},
+			CmpFunc: func(got, exp any) string {
+				g, ok := got.(*settingsapp.Setting)
+				if !ok {
+					return "got type assertion failed"
+				}
+				e, ok := exp.(*settingsapp.Setting)
+				if !ok {
+					return "exp type assertion failed"
+				}
+				if g.Key != e.Key || string(g.Value) != string(e.Value) {
+					return cmp.Diff(
+						map[string]string{"key": g.Key, "value": string(g.Value)},
+						map[string]string{"key": e.Key, "value": string(e.Value)},
+					)
+				}
+				return ""
 			},
 		},
 	}

--- a/api/cmd/services/ichor/tests/scenarios/scenarioapi/main_test.go
+++ b/api/cmd/services/ichor/tests/scenarios/scenarioapi/main_test.go
@@ -32,4 +32,8 @@ func Test_Scenarios(t *testing.T) {
 	test.Run(t, load401(sd), "load-401")
 	test.Run(t, load404(sd), "load-404")
 	test.Run(t, load204(sd), "load-204")
+	// load-with-overrides-204 runs last: it re-loads scenarios[1] (which has a
+	// pre-seeded override) and then asserts GET /v1/config/settings/{key}
+	// returns the merged override value.
+	test.Run(t, loadWithOverrides204(sd), "load-with-overrides-204")
 }

--- a/api/cmd/services/ichor/tests/scenarios/scenarioapi/seed_test.go
+++ b/api/cmd/services/ichor/tests/scenarios/scenarioapi/seed_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/timmaaaz/ichor/api/domain/http/scenarios/scenarioapi"
 	"github.com/timmaaaz/ichor/api/sdk/http/apitest"
 	"github.com/timmaaaz/ichor/app/sdk/auth"
+	"github.com/timmaaaz/ichor/business/domain/config/settingsbus"
+	"github.com/timmaaaz/ichor/business/domain/config/settingsbus/levers"
 	"github.com/timmaaaz/ichor/business/domain/core/rolebus"
 	"github.com/timmaaaz/ichor/business/domain/core/tableaccessbus"
 	"github.com/timmaaaz/ichor/business/domain/core/userbus"
@@ -148,6 +150,31 @@ func insertSeedData(db *dbtest.Database, ath *auth.Auth) (apitest.SeedData, erro
 				return apitest.SeedData{}, fmt.Errorf("updating table access: %w", err)
 			}
 		}
+	}
+
+	// Phase 0g.B5 — seed 11 lever defaults so the settings GET endpoint has
+	// rows to return. Required before seeding overrides.
+	for _, key := range levers.KnownKeys {
+		raw, err := json.Marshal(levers.Defaults[key])
+		if err != nil {
+			return apitest.SeedData{}, fmt.Errorf("seed setting marshal %s: %w", key, err)
+		}
+		ns := settingsbus.NewSetting{
+			Key:         key,
+			Value:       json.RawMessage(raw),
+			Description: "apitest lever seed",
+		}
+		if _, err := busDomain.Settings.Create(ctx, ns); err != nil {
+			return apitest.SeedData{}, fmt.Errorf("seed setting %s: %w", key, err)
+		}
+	}
+
+	// Pre-seed a lever override on scenarios[1] so loadWithOverrides204 can
+	// assert the merged override is visible via GET /v1/config/settings/{key}.
+	if err := busDomain.Scenario.SeedApplyLeverOverrides(ctx, scenarios[1].ID, map[string]string{
+		"pick.lotScan": "required-if-lot-tracked",
+	}); err != nil {
+		return apitest.SeedData{}, fmt.Errorf("seed lever overrides: %w", err)
 	}
 
 	return apitest.SeedData{

--- a/business/domain/config/settingsbus/levers/levers.go
+++ b/business/domain/config/settingsbus/levers/levers.go
@@ -46,3 +46,16 @@ func IsKnown(key string) bool {
 	_, ok := Defaults[key]
 	return ok
 }
+
+// nonOverridableKeys holds keys that exist in Defaults for resolver
+// completeness but must never be changed by a scenario or customer override.
+// Per design doc §3.3 invariant 1, pick.productScan is locked to "required".
+var nonOverridableKeys = map[string]bool{
+	"pick.productScan": true,
+}
+
+// IsOverridable reports whether key may appear in scenario lever_overrides.
+// All known keys are overridable except those locked by design invariants.
+func IsOverridable(key string) bool {
+	return IsKnown(key) && !nonOverridableKeys[key]
+}

--- a/business/domain/config/settingsbus/levers/levers.go
+++ b/business/domain/config/settingsbus/levers/levers.go
@@ -1,0 +1,50 @@
+// Package levers owns the canonical list of scan-discipline lever keys
+// and their SMB defaults. Seeders, validators, and tests import this
+// package as the single source of truth so the three never drift.
+//
+// See docs/superpowers/specs/2026-04-24-label-scan-workflow-redesign.md §3.3
+// for the per-key semantics and the SMB-vs-strict-regulated contrast.
+package levers
+
+// KnownKeys is the complete, sorted list of lever keys. Sorted to
+// stabilize seed insert order and test diff output.
+var KnownKeys = []string{
+	"pick.assignmentGranularity",
+	"pick.destinationMode",
+	"pick.destinationScan",
+	"pick.lotScan",
+	"pick.productScan",
+	"pick.sourceLocationScan",
+	"receive.expiryCapture",
+	"receive.lotCapture",
+	"receive.poScan",
+	"transfer.destinationScan",
+	"transfer.sourceLocationScan",
+}
+
+// Defaults is the SMB-default value for every lever key. Per design doc
+// §3.3 invariant 1, pick.productScan is always "required" and intentionally
+// not exposed as a configurable lever — included here for resolver
+// completeness, NOT for customer override.
+var Defaults = map[string]string{
+	"pick.assignmentGranularity":  "whole-order",
+	"pick.destinationMode":        "direct-stage",
+	"pick.destinationScan":        "button-confirm",
+	"pick.lotScan":                "disabled",
+	"pick.productScan":            "required",
+	"pick.sourceLocationScan":     "button-confirm",
+	"receive.expiryCapture":       "required-if-lot-tracked",
+	"receive.lotCapture":          "required-if-lot-tracked",
+	"receive.poScan":              "required",
+	"transfer.destinationScan":    "button-confirm",
+	"transfer.sourceLocationScan": "button-confirm",
+}
+
+// IsKnown reports whether key is one of the canonical lever keys. Used by
+// scenario YAML validation to reject typos in lever_overrides.
+func IsKnown(key string) bool {
+	if _, ok := Defaults[key]; ok {
+		return true
+	}
+	return false
+}

--- a/business/domain/config/settingsbus/levers/levers.go
+++ b/business/domain/config/settingsbus/levers/levers.go
@@ -43,8 +43,6 @@ var Defaults = map[string]string{
 // IsKnown reports whether key is one of the canonical lever keys. Used by
 // scenario YAML validation to reject typos in lever_overrides.
 func IsKnown(key string) bool {
-	if _, ok := Defaults[key]; ok {
-		return true
-	}
-	return false
+	_, ok := Defaults[key]
+	return ok
 }

--- a/business/domain/config/settingsbus/levers/levers_test.go
+++ b/business/domain/config/settingsbus/levers/levers_test.go
@@ -42,12 +42,7 @@ func Test_Defaults_ProductScan_AlwaysRequired(t *testing.T) {
 
 func Test_KnownKeys_Sorted(t *testing.T) {
 	// Stable iteration for seeders + test output diffability.
-	got := append([]string{}, levers.KnownKeys...)
-	want := append([]string{}, levers.KnownKeys...)
-	sort.Strings(want)
-	for i := range got {
-		if got[i] != want[i] {
-			t.Fatalf("KnownKeys not sorted at index %d: got %q, want %q", i, got[i], want[i])
-		}
+	if !sort.StringsAreSorted(levers.KnownKeys) {
+		t.Fatalf("KnownKeys is not sorted: %v", levers.KnownKeys)
 	}
 }

--- a/business/domain/config/settingsbus/levers/levers_test.go
+++ b/business/domain/config/settingsbus/levers/levers_test.go
@@ -46,3 +46,27 @@ func Test_KnownKeys_Sorted(t *testing.T) {
 		t.Fatalf("KnownKeys is not sorted: %v", levers.KnownKeys)
 	}
 }
+
+func Test_IsOverridable_ProductScanReturnsFalse(t *testing.T) {
+	// Per design doc §3.3 invariant 1, pick.productScan is locked.
+	if levers.IsOverridable("pick.productScan") {
+		t.Fatal("IsOverridable(pick.productScan) = true, want false")
+	}
+}
+
+func Test_IsOverridable_OtherKnownKeysReturnTrue(t *testing.T) {
+	for _, k := range levers.KnownKeys {
+		if k == "pick.productScan" {
+			continue
+		}
+		if !levers.IsOverridable(k) {
+			t.Errorf("IsOverridable(%q) = false, want true", k)
+		}
+	}
+}
+
+func Test_IsOverridable_UnknownKeyReturnsFalse(t *testing.T) {
+	if levers.IsOverridable("pick.notALever") {
+		t.Fatal("IsOverridable(pick.notALever) = true, want false")
+	}
+}

--- a/business/domain/config/settingsbus/levers/levers_test.go
+++ b/business/domain/config/settingsbus/levers/levers_test.go
@@ -1,0 +1,53 @@
+package levers_test
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/timmaaaz/ichor/business/domain/config/settingsbus/levers"
+)
+
+func Test_Defaults_HasExactlyElevenKeys(t *testing.T) {
+	if got, want := len(levers.Defaults), 11; got != want {
+		t.Fatalf("len(Defaults) = %d, want %d", got, want)
+	}
+}
+
+func Test_Defaults_AllKnownKeysHaveDefaults(t *testing.T) {
+	for _, k := range levers.KnownKeys {
+		if _, ok := levers.Defaults[k]; !ok {
+			t.Errorf("KnownKeys contains %q but Defaults has no entry", k)
+		}
+	}
+}
+
+func Test_Defaults_NoExtraKeys(t *testing.T) {
+	known := make(map[string]bool, len(levers.KnownKeys))
+	for _, k := range levers.KnownKeys {
+		known[k] = true
+	}
+	for k := range levers.Defaults {
+		if !known[k] {
+			t.Errorf("Defaults contains %q but it is not in KnownKeys", k)
+		}
+	}
+}
+
+func Test_Defaults_ProductScan_AlwaysRequired(t *testing.T) {
+	// Per design doc §3.3 invariant: pick.productScan is always required.
+	if got := levers.Defaults["pick.productScan"]; got != "required" {
+		t.Fatalf("pick.productScan default = %q, want %q (invariant)", got, "required")
+	}
+}
+
+func Test_KnownKeys_Sorted(t *testing.T) {
+	// Stable iteration for seeders + test output diffability.
+	got := append([]string{}, levers.KnownKeys...)
+	want := append([]string{}, levers.KnownKeys...)
+	sort.Strings(want)
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("KnownKeys not sorted at index %d: got %q, want %q", i, got[i], want[i])
+		}
+	}
+}

--- a/business/domain/config/settingsbus/stores/settingsdb/filter.go
+++ b/business/domain/config/settingsbus/stores/settingsdb/filter.go
@@ -12,12 +12,12 @@ func applyFilter(filter settingsbus.QueryFilter, data map[string]any, buf *bytes
 
 	if filter.Key != nil {
 		data["key"] = *filter.Key
-		wc = append(wc, "key = :key")
+		wc = append(wc, "s.key = :key")
 	}
 
 	if filter.Prefix != nil {
 		data["prefix"] = *filter.Prefix + "%"
-		wc = append(wc, "key LIKE :prefix")
+		wc = append(wc, "s.key LIKE :prefix")
 	}
 
 	if len(wc) > 0 {

--- a/business/domain/config/settingsbus/stores/settingsdb/settingsdb.go
+++ b/business/domain/config/settingsbus/stores/settingsdb/settingsdb.go
@@ -89,6 +89,10 @@ func (s *Store) Query(ctx context.Context, filter settingsbus.QueryFilter, order
 		"rows_per_page": page.RowsPerPage(),
 	}
 
+	// CASE not COALESCE: to_jsonb(NULL::text) returns jsonb-null (a non-NULL
+	// jsonb value), so COALESCE(to_jsonb(o.value), s.value) would pick the
+	// jsonb-null over the base when no override exists. The CASE form
+	// explicitly checks SQL-NULL to fall through to s.value.
 	const q = `
 	WITH active AS (
 	    SELECT scenario_id FROM inventory.scenarios_active LIMIT 1
@@ -135,7 +139,7 @@ func (s *Store) Count(ctx context.Context, filter settingsbus.QueryFilter) (int,
     SELECT
         COUNT(1) AS count
     FROM
-        config.settings`
+        config.settings s`
 
 	buf := bytes.NewBufferString(q)
 	applyFilter(filter, data, buf)
@@ -156,6 +160,10 @@ func (s *Store) QueryByKey(ctx context.Context, key string) (settingsbus.Setting
 		Key string `db:"key"`
 	}{Key: key}
 
+	// CASE not COALESCE: to_jsonb(NULL::text) returns jsonb-null (a non-NULL
+	// jsonb value), so COALESCE(to_jsonb(o.value), s.value) would pick the
+	// jsonb-null over the base when no override exists. The CASE form
+	// explicitly checks SQL-NULL to fall through to s.value.
 	const q = `
 	WITH active AS (
 	    SELECT scenario_id FROM inventory.scenarios_active LIMIT 1

--- a/business/domain/config/settingsbus/stores/settingsdb/settingsdb.go
+++ b/business/domain/config/settingsbus/stores/settingsdb/settingsdb.go
@@ -90,10 +90,24 @@ func (s *Store) Query(ctx context.Context, filter settingsbus.QueryFilter, order
 	}
 
 	const q = `
+	WITH active AS (
+	    SELECT scenario_id FROM inventory.scenarios_active LIMIT 1
+	)
 	SELECT
-	    key, value, description, created_date, updated_date
+	    s.key                                              AS key,
+	    CASE
+	        WHEN o.value IS NOT NULL THEN to_jsonb(o.value)
+	        ELSE s.value
+	    END                                               AS value,
+	    s.description                                     AS description,
+	    s.created_date                                    AS created_date,
+	    s.updated_date                                    AS updated_date
 	FROM
-		config.settings`
+	    config.settings s
+	    LEFT JOIN active a ON TRUE
+	    LEFT JOIN config.scenario_setting_overrides o
+	        ON o.scenario_id = a.scenario_id
+	       AND o.key         = s.key`
 
 	buf := bytes.NewBufferString(q)
 	applyFilter(filter, data, buf)
@@ -143,12 +157,26 @@ func (s *Store) QueryByKey(ctx context.Context, key string) (settingsbus.Setting
 	}{Key: key}
 
 	const q = `
+	WITH active AS (
+	    SELECT scenario_id FROM inventory.scenarios_active LIMIT 1
+	)
 	SELECT
-	    key, value, description, created_date, updated_date
+	    s.key                                              AS key,
+	    CASE
+	        WHEN o.value IS NOT NULL THEN to_jsonb(o.value)
+	        ELSE s.value
+	    END                                               AS value,
+	    s.description                                     AS description,
+	    s.created_date                                    AS created_date,
+	    s.updated_date                                    AS updated_date
 	FROM
-		config.settings
+	    config.settings s
+	    LEFT JOIN active a ON TRUE
+	    LEFT JOIN config.scenario_setting_overrides o
+	        ON o.scenario_id = a.scenario_id
+	       AND o.key         = s.key
 	WHERE
-		key = :key`
+	    s.key = :key`
 
 	var dbSetting setting
 	if err := sqldb.NamedQueryStruct(ctx, s.log, s.db, q, data, &dbSetting); err != nil {

--- a/business/domain/core/tableaccessbus/testutil.go
+++ b/business/domain/core/tableaccessbus/testutil.go
@@ -92,6 +92,7 @@ func TestSeedTableAccess(ctx context.Context, roleIDs uuid.UUIDs, api *Business)
 		{RoleID: uuid.Nil, TableName: "procurement.purchase_order_line_items", CanCreate: true, CanRead: true, CanUpdate: true, CanDelete: true},
 
 		// Config schema
+		{RoleID: uuid.Nil, TableName: "config.settings", CanCreate: true, CanRead: true, CanUpdate: true, CanDelete: true},
 		{RoleID: uuid.Nil, TableName: "config.table_configs", CanCreate: true, CanRead: true, CanUpdate: true, CanDelete: true},
 		{RoleID: uuid.Nil, TableName: "config.forms", CanCreate: true, CanRead: true, CanUpdate: true, CanDelete: true},
 		{RoleID: uuid.Nil, TableName: "config.form_fields", CanCreate: true, CanRead: true, CanUpdate: true, CanDelete: true},

--- a/business/domain/scenarios/scenariobus/model.go
+++ b/business/domain/scenarios/scenariobus/model.go
@@ -44,3 +44,20 @@ type NewScenarioFixture struct {
 	TargetTable string
 	PayloadJSON []byte
 }
+
+// WorkerZoneBinding represents a single user→zones assignment applied to
+// core.users.assigned_zones at scenario Load time. Bus-layer value type;
+// yamlload.WorkerBinding is the YAML-layer parallel.
+type WorkerZoneBinding struct {
+	Username string
+	Zones    []string
+}
+
+// SettingOverride represents one row of config.scenario_setting_overrides.
+// Persisted at seed time (see seed_scenarios.go) so the settings resolver
+// LEFT JOIN sees a stable per-scenario override layer.
+type SettingOverride struct {
+	ScenarioID uuid.UUID
+	Key        string
+	Value      string
+}

--- a/business/domain/scenarios/scenariobus/scenariobus.go
+++ b/business/domain/scenarios/scenariobus/scenariobus.go
@@ -12,8 +12,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/google/uuid"
@@ -81,28 +79,9 @@ type Business struct {
 // disables worker-zone application during Load (e.g. in unit tests that
 // don't exercise the YAML path). The seeder discovers this path via
 // findRepoRoot in seed_scenarios.go and the API binary wires it via
-// build/all/all.go (Task 11 Step 4).
+// build/all/all.go.
 func NewBusiness(log *logger.Logger, d *delegate.Delegate, storer Storer, beginner sqldb.Beginner, scenariosRoot string) *Business {
 	return &Business{log: log, delegate: d, storer: storer, beginner: beginner, scenariosRoot: scenariosRoot}
-}
-
-// FindScenariosRoot walks upward from cwd looking for go.mod and returns
-// <root>/deployments/scenarios. Mirrors seed_scenarios.go's findRepoRoot.
-func FindScenariosRoot() (string, error) {
-	dir, err := os.Getwd()
-	if err != nil {
-		return "", fmt.Errorf("getwd: %w", err)
-	}
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			return filepath.Join(dir, "deployments", "scenarios"), nil
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			return "", fmt.Errorf("go.mod not found from %s upward", dir)
-		}
-		dir = parent
-	}
 }
 
 // NewWithTx constructs a new Business value replacing the Storer value with
@@ -314,7 +293,9 @@ func (b *Business) SetActive(ctx context.Context, id uuid.UUID) error {
 //  2. Deletes all scoped rows from the 18 floor-scoped tables for the
 //     current active scenario (if one is set).
 //  3. Inserts fixture rows for the target scenario via ApplyFixtures.
-//  4. Updates scenarios_active to the target scenario.
+//  4. Applies worker→zone bindings via ApplyWorkerZones (skipped when
+//     scenariosRoot is empty, e.g. test contexts without YAML on disk).
+//  5. Updates scenarios_active to the target scenario.
 //
 // Delegate events are NOT fired from Load — this is a bulk mutation that
 // bypasses individual workflow automation triggers by design. The operation

--- a/business/domain/scenarios/scenariobus/scenariobus.go
+++ b/business/domain/scenarios/scenariobus/scenariobus.go
@@ -12,9 +12,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/timmaaaz/ichor/business/domain/scenarios/scenariobus/yamlload"
 	"github.com/timmaaaz/ichor/business/sdk/delegate"
 	"github.com/timmaaaz/ichor/business/sdk/order"
 	"github.com/timmaaaz/ichor/business/sdk/page"
@@ -65,15 +68,41 @@ type Storer interface {
 
 // Business manages the set of APIs for scenario access.
 type Business struct {
-	log      *logger.Logger
-	delegate *delegate.Delegate
-	storer   Storer
-	beginner sqldb.Beginner
+	log           *logger.Logger
+	delegate      *delegate.Delegate
+	storer        Storer
+	beginner      sqldb.Beginner
+	scenariosRoot string // filesystem path to deployments/scenarios/ — empty disables worker-zone application
 }
 
 // NewBusiness constructs a scenario business API for use.
-func NewBusiness(log *logger.Logger, d *delegate.Delegate, storer Storer, beginner sqldb.Beginner) *Business {
-	return &Business{log: log, delegate: d, storer: storer, beginner: beginner}
+//
+// scenariosRoot is the absolute path to deployments/scenarios/. Empty string
+// disables worker-zone application during Load (e.g. in unit tests that
+// don't exercise the YAML path). The seeder discovers this path via
+// findRepoRoot in seed_scenarios.go and the API binary wires it via
+// build/all/all.go (Task 11 Step 4).
+func NewBusiness(log *logger.Logger, d *delegate.Delegate, storer Storer, beginner sqldb.Beginner, scenariosRoot string) *Business {
+	return &Business{log: log, delegate: d, storer: storer, beginner: beginner, scenariosRoot: scenariosRoot}
+}
+
+// FindScenariosRoot walks upward from cwd looking for go.mod and returns
+// <root>/deployments/scenarios. Mirrors seed_scenarios.go's findRepoRoot.
+func FindScenariosRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("getwd: %w", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return filepath.Join(dir, "deployments", "scenarios"), nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("go.mod not found from %s upward", dir)
+		}
+		dir = parent
+	}
 }
 
 // NewWithTx constructs a new Business value replacing the Storer value with
@@ -85,10 +114,11 @@ func (b *Business) NewWithTx(tx sqldb.CommitRollbacker) (*Business, error) {
 	}
 
 	return &Business{
-		log:      b.log,
-		delegate: b.delegate,
-		storer:   storer,
-		beginner: b.beginner,
+		log:           b.log,
+		delegate:      b.delegate,
+		storer:        storer,
+		beginner:      b.beginner,
+		scenariosRoot: b.scenariosRoot,
 	}, nil
 }
 
@@ -328,6 +358,21 @@ func (b *Business) Load(ctx context.Context, id uuid.UUID) error {
 		return fmt.Errorf("load applyfixtures: %w", err)
 	}
 
+	// Phase 0g.B5 — apply worker→zone bindings. Re-reads YAML at Load time
+	// because Bindings.Workers is not persisted (see plan §Architecture
+	// deviation 1). Empty scenariosRoot (test contexts) disables this path.
+	if b.scenariosRoot != "" {
+		zones, err := readWorkerZonesForScenario(b.scenariosRoot, id, b.storer)
+		if err != nil {
+			tx.Rollback()
+			return fmt.Errorf("load read worker zones: %w", err)
+		}
+		if err := txBus.storer.ApplyWorkerZones(ctx, zones); err != nil {
+			tx.Rollback()
+			return fmt.Errorf("load apply worker zones: %w", err)
+		}
+	}
+
 	// Update the active pointer.
 	if err := txBus.storer.SetActive(ctx, id); err != nil {
 		tx.Rollback()
@@ -363,5 +408,32 @@ func (b *Business) Reset(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// readWorkerZonesForScenario re-reads the on-disk scenario directory matching
+// the given UUID and returns its worker bindings as bus-layer values. The
+// matching uses the deterministic scenario ID (uuid.NewSHA1 of "scenario:"+name
+// under the deadbeef namespace, set in yamlload.loadOne). Returns empty slice
+// if the scenario has no workers binding or if the scenariosRoot directory
+// holds no matching scenario.
+func readWorkerZonesForScenario(scenariosRoot string, id uuid.UUID, _ Storer) ([]WorkerZoneBinding, error) {
+	scenarios, err := yamlload.Load(scenariosRoot)
+	if err != nil {
+		if yamlload.IsNotFoundErr(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("yamlload.Load: %w", err)
+	}
+	for _, s := range scenarios {
+		if s.ID != id {
+			continue
+		}
+		out := make([]WorkerZoneBinding, 0, len(s.Bindings.Workers))
+		for _, w := range s.Bindings.Workers {
+			out = append(out, WorkerZoneBinding{Username: w.Username, Zones: w.Zones})
+		}
+		return out, nil
+	}
+	return nil, nil
 }
 

--- a/business/domain/scenarios/scenariobus/scenariobus.go
+++ b/business/domain/scenarios/scenariobus/scenariobus.go
@@ -53,6 +53,14 @@ type Storer interface {
 	// bulk load/reset
 	ApplyFixtures(ctx context.Context, target uuid.UUID) error
 	DeleteScopedRows(ctx context.Context, scenarioID uuid.UUID) error
+
+	// scenario_setting_overrides table — written at seed time, read via JOIN
+	// in settingsdb.Query.
+	ApplyLeverOverrides(ctx context.Context, overrides []SettingOverride) error
+
+	// core.users.assigned_zones — applied at scenario Load time inside the
+	// same TX as ApplyFixtures. Each binding is one UPDATE.
+	ApplyWorkerZones(ctx context.Context, zones []WorkerZoneBinding) error
 }
 
 // Business manages the set of APIs for scenario access.

--- a/business/domain/scenarios/scenariobus/scenariobus.go
+++ b/business/domain/scenarios/scenariobus/scenariobus.go
@@ -27,9 +27,9 @@ import (
 
 // Set of error variables for CRUD operations.
 var (
-	ErrNotFound          = errors.New("scenario not found")
-	ErrUniqueName        = errors.New("scenario name already exists")
-	ErrNoActiveScenario  = errors.New("no active scenario set")
+	ErrNotFound         = errors.New("scenario not found")
+	ErrUniqueName       = errors.New("scenario name already exists")
+	ErrNoActiveScenario = errors.New("no active scenario set")
 )
 
 // Storer declares the behavior needed to persist and retrieve scenario data.
@@ -359,8 +359,10 @@ func (b *Business) Load(ctx context.Context, id uuid.UUID) error {
 	}
 
 	// Phase 0g.B5 — apply worker→zone bindings. Re-reads YAML at Load time
-	// because Bindings.Workers is not persisted (see plan §Architecture
-	// deviation 1). Empty scenariosRoot (test contexts) disables this path.
+	// because Bindings.Workers is intentionally NOT persisted: workers and
+	// their zone assignments are operational data (core.users.assigned_zones)
+	// and the YAML is the single source of truth. Empty scenariosRoot (test
+	// contexts) disables this path.
 	if b.scenariosRoot != "" {
 		zones, err := readWorkerZonesForScenario(b.scenariosRoot, id)
 		if err != nil {
@@ -436,4 +438,3 @@ func readWorkerZonesForScenario(scenariosRoot string, id uuid.UUID) ([]WorkerZon
 	}
 	return nil, nil
 }
-

--- a/business/domain/scenarios/scenariobus/scenariobus.go
+++ b/business/domain/scenarios/scenariobus/scenariobus.go
@@ -141,6 +141,24 @@ func (b *Business) SeedCreateFixture(ctx context.Context, f ScenarioFixture) err
 	return nil
 }
 
+// SeedApplyLeverOverrides inserts (or upserts) lever-override rows for the
+// given scenario. Seed-only — at runtime, overrides are mutated only
+// indirectly through reseed. Idempotent: ON CONFLICT DO UPDATE on PK
+// (scenario_id, key).
+func (b *Business) SeedApplyLeverOverrides(ctx context.Context, scenarioID uuid.UUID, overrides map[string]string) error {
+	if len(overrides) == 0 {
+		return nil
+	}
+	rows := make([]SettingOverride, 0, len(overrides))
+	for k, v := range overrides {
+		rows = append(rows, SettingOverride{ScenarioID: scenarioID, Key: k, Value: v})
+	}
+	if err := b.storer.ApplyLeverOverrides(ctx, rows); err != nil {
+		return fmt.Errorf("seedapply lever overrides: %w", err)
+	}
+	return nil
+}
+
 // Update applies a partial patch to an existing scenario.
 func (b *Business) Update(ctx context.Context, s Scenario, us UpdateScenario) (Scenario, error) {
 	before := s

--- a/business/domain/scenarios/scenariobus/scenariobus.go
+++ b/business/domain/scenarios/scenariobus/scenariobus.go
@@ -362,7 +362,7 @@ func (b *Business) Load(ctx context.Context, id uuid.UUID) error {
 	// because Bindings.Workers is not persisted (see plan §Architecture
 	// deviation 1). Empty scenariosRoot (test contexts) disables this path.
 	if b.scenariosRoot != "" {
-		zones, err := readWorkerZonesForScenario(b.scenariosRoot, id, b.storer)
+		zones, err := readWorkerZonesForScenario(b.scenariosRoot, id)
 		if err != nil {
 			tx.Rollback()
 			return fmt.Errorf("load read worker zones: %w", err)
@@ -416,7 +416,7 @@ func (b *Business) Reset(ctx context.Context) error {
 // under the deadbeef namespace, set in yamlload.loadOne). Returns empty slice
 // if the scenario has no workers binding or if the scenariosRoot directory
 // holds no matching scenario.
-func readWorkerZonesForScenario(scenariosRoot string, id uuid.UUID, _ Storer) ([]WorkerZoneBinding, error) {
+func readWorkerZonesForScenario(scenariosRoot string, id uuid.UUID) ([]WorkerZoneBinding, error) {
 	scenarios, err := yamlload.Load(scenariosRoot)
 	if err != nil {
 		if yamlload.IsNotFoundErr(err) {

--- a/business/domain/scenarios/scenariobus/scenariobus_load_test.go
+++ b/business/domain/scenarios/scenariobus/scenariobus_load_test.go
@@ -1,0 +1,136 @@
+package scenariobus_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/timmaaaz/ichor/business/domain/core/userbus"
+	"github.com/timmaaaz/ichor/business/domain/scenarios/scenariobus"
+	"github.com/timmaaaz/ichor/business/domain/scenarios/scenariobus/stores/scenariodb"
+	"github.com/timmaaaz/ichor/business/sdk/dbtest"
+	"github.com/timmaaaz/ichor/business/sdk/page"
+	"github.com/timmaaaz/ichor/business/sdk/sqldb"
+)
+
+// Test_Load_AppliesLeverOverrides_AndWorkerZones runs the full Load path
+// against a real DB. It writes a temporary scenario directory on disk, seeds
+// the DB via SeedScenariosFromRoot, calls Load, and asserts both
+// override-visibility (via settingsdb's scenario JOIN) and worker-zone effects.
+func Test_Load_AppliesLeverOverrides_AndWorkerZones(t *testing.T) {
+	t.Parallel()
+
+	db := dbtest.NewDatabase(t, "Test_Load_AppliesLeverOverrides_AndWorkerZones")
+	ctx := context.Background()
+
+	// Baseline seed — populates config.settings (11 levers) plus all FK
+	// dependencies required by the user bus.
+	if err := dbtest.InsertSeedDataWithDB(db.Log, db.DB); err != nil {
+		t.Fatalf("baseline seed: %v", err)
+	}
+
+	// Create 1 user with a known username so the bindings.yaml can reference it.
+	users, err := userbus.TestSeedUsersWithNoFKs(ctx, 1, userbus.Roles.User, db.BusDomain.User)
+	if err != nil {
+		t.Fatalf("seed worker user: %v", err)
+	}
+	workerUsername := users[0].Username.String()
+
+	// Build temporary scenario directory: one scenario subdirectory under
+	// scenariosRoot containing scenario.yaml + bindings.yaml (no state.yaml).
+	scenariosRoot := t.TempDir()
+	scenarioDir := filepath.Join(scenariosRoot, "test-levers")
+	if err := os.MkdirAll(scenarioDir, 0o755); err != nil {
+		t.Fatalf("mkdir scenario dir: %v", err)
+	}
+
+	scenarioYAML := "name: test-levers\ndescription: B5 integration test\nlever_overrides:\n  pick.lotScan: required-if-lot-tracked\n  pick.destinationScan: required\n"
+	if err := os.WriteFile(filepath.Join(scenarioDir, "scenario.yaml"), []byte(scenarioYAML), 0o644); err != nil {
+		t.Fatalf("write scenario.yaml: %v", err)
+	}
+
+	bindingsYAML := fmt.Sprintf("workers:\n  - username: %s\n    zones: [PCK, STG-Z]\n", workerUsername)
+	if err := os.WriteFile(filepath.Join(scenarioDir, "bindings.yaml"), []byte(bindingsYAML), 0o644); err != nil {
+		t.Fatalf("write bindings.yaml: %v", err)
+	}
+
+	// Seed scenario row + lever_override rows into the DB from the temp dir.
+	if err := dbtest.SeedScenariosFromRoot(ctx, db.BusDomain, scenariosRoot); err != nil {
+		t.Fatalf("seed temp scenario: %v", err)
+	}
+
+	// Look up the scenario ID by name using the default (empty-root) bus.
+	target, err := db.BusDomain.Scenario.QueryByName(ctx, "test-levers")
+	if err != nil {
+		t.Fatalf("query scenario by name: %v", err)
+	}
+
+	// Build a fresh scenariobus.Business wired to the temp scenariosRoot so
+	// Load can read worker zones from bindings.yaml.  The default
+	// db.BusDomain.Scenario was constructed with "" (no-op worker zone path).
+	scenarioBus := scenariobus.NewBusiness(
+		db.Log,
+		db.BusDomain.Delegate,
+		scenariodb.NewStore(db.Log, db.DB),
+		sqldb.NewBeginner(db.DB),
+		scenariosRoot,
+	)
+
+	// Load the scenario — applies fixtures (none here), sets scenarios_active,
+	// and applies worker zone bindings.
+	if err := scenarioBus.Load(ctx, target.ID); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	// Assert: override visible via settingsdb's scenario JOIN.
+	// pick.lotScan default is "disabled"; override must win.
+	lotScanSetting, err := db.BusDomain.Settings.QueryByKey(ctx, "pick.lotScan")
+	if err != nil {
+		t.Fatalf("query pick.lotScan: %v", err)
+	}
+	var lotScanValue string
+	if err := json.Unmarshal(lotScanSetting.Value, &lotScanValue); err != nil {
+		t.Fatalf("unmarshal pick.lotScan value: %v", err)
+	}
+	if lotScanValue != "required-if-lot-tracked" {
+		t.Errorf("pick.lotScan = %q, want %q (override should win)", lotScanValue, "required-if-lot-tracked")
+	}
+
+	// Assert: non-overridden key returns base default.
+	// pick.assignmentGranularity was NOT overridden; base default is "whole-order".
+	granSetting, err := db.BusDomain.Settings.QueryByKey(ctx, "pick.assignmentGranularity")
+	if err != nil {
+		t.Fatalf("query pick.assignmentGranularity: %v", err)
+	}
+	var granValue string
+	if err := json.Unmarshal(granSetting.Value, &granValue); err != nil {
+		t.Fatalf("unmarshal pick.assignmentGranularity value: %v", err)
+	}
+	if granValue != "whole-order" {
+		t.Errorf("pick.assignmentGranularity = %q, want %q (base default should hold)", granValue, "whole-order")
+	}
+
+	// Assert: worker zones were applied to the user.
+	uname := userbus.MustParseName(workerUsername)
+	queried, err := db.BusDomain.User.Query(
+		ctx,
+		userbus.QueryFilter{Username: &uname},
+		userbus.DefaultOrderBy,
+		page.MustParse("1", "10"),
+	)
+	if err != nil {
+		t.Fatalf("user query: %v", err)
+	}
+	if len(queried) == 0 {
+		t.Fatalf("user %q not found after Load", workerUsername)
+	}
+	gotZones := queried[0].AssignedZones
+	wantZones := []string{"PCK", "STG-Z"}
+	if !slices.Equal(gotZones, wantZones) {
+		t.Errorf("user %q assigned_zones = %v, want %v", workerUsername, gotZones, wantZones)
+	}
+}

--- a/business/domain/scenarios/scenariobus/scenariobus_load_test.go
+++ b/business/domain/scenarios/scenariobus/scenariobus_load_test.go
@@ -133,4 +133,41 @@ func Test_Load_AppliesLeverOverrides_AndWorkerZones(t *testing.T) {
 	if !slices.Equal(gotZones, wantZones) {
 		t.Errorf("user %q assigned_zones = %v, want %v", workerUsername, gotZones, wantZones)
 	}
+
+	// Reset re-applies the active scenario via Load. The DoD asserts "Scenario
+	// reset restores default config state" — for B5, that means override
+	// visibility and worker zones survive a Reset round-trip unchanged.
+	if err := scenarioBus.Reset(ctx); err != nil {
+		t.Fatalf("Reset: %v", err)
+	}
+
+	// Re-assert override still wins post-Reset.
+	lotScanSetting2, err := db.BusDomain.Settings.QueryByKey(ctx, "pick.lotScan")
+	if err != nil {
+		t.Fatalf("query pick.lotScan post-Reset: %v", err)
+	}
+	var lotScanValue2 string
+	if err := json.Unmarshal(lotScanSetting2.Value, &lotScanValue2); err != nil {
+		t.Fatalf("unmarshal pick.lotScan value post-Reset: %v", err)
+	}
+	if lotScanValue2 != "required-if-lot-tracked" {
+		t.Errorf("post-Reset pick.lotScan = %q, want %q (override should still win)", lotScanValue2, "required-if-lot-tracked")
+	}
+
+	// Re-assert worker zones still applied post-Reset.
+	queried2, err := db.BusDomain.User.Query(
+		ctx,
+		userbus.QueryFilter{Username: &uname},
+		userbus.DefaultOrderBy,
+		page.MustParse("1", "10"),
+	)
+	if err != nil {
+		t.Fatalf("user query post-Reset: %v", err)
+	}
+	if len(queried2) == 0 {
+		t.Fatalf("user %q not found post-Reset", workerUsername)
+	}
+	if !slices.Equal(queried2[0].AssignedZones, wantZones) {
+		t.Errorf("post-Reset user %q assigned_zones = %v, want %v", workerUsername, queried2[0].AssignedZones, wantZones)
+	}
 }

--- a/business/domain/scenarios/scenariobus/scenariobus_test.go
+++ b/business/domain/scenarios/scenariobus/scenariobus_test.go
@@ -14,7 +14,7 @@ import (
 func Test_NewBusiness(t *testing.T) {
 	var buf bytes.Buffer
 	log := logger.New(&buf, logger.LevelInfo, "TEST", func(context.Context) string { return otel.GetTraceID(context.Background()) })
-	bus := scenariobus.NewBusiness(log, delegate.New(log), nil, nil)
+	bus := scenariobus.NewBusiness(log, delegate.New(log), nil, nil, "")
 	if bus == nil {
 		t.Fatalf("NewBusiness returned nil")
 	}

--- a/business/domain/scenarios/scenariobus/stores/scenariodb/scenariodb.go
+++ b/business/domain/scenarios/scenariobus/stores/scenariodb/scenariodb.go
@@ -13,6 +13,7 @@ import (
 	"github.com/timmaaaz/ichor/business/sdk/order"
 	"github.com/timmaaaz/ichor/business/sdk/page"
 	"github.com/timmaaaz/ichor/business/sdk/sqldb"
+	"github.com/timmaaaz/ichor/business/sdk/sqldb/dbarray"
 	"github.com/timmaaaz/ichor/foundation/logger"
 )
 
@@ -400,5 +401,74 @@ func (s *Store) ApplyFixtures(ctx context.Context, target uuid.UUID) error {
 		}
 	}
 
+	return nil
+}
+
+// =============================================================================
+// Lever overrides + worker zones
+// =============================================================================
+
+// ApplyLeverOverrides upserts rows into config.scenario_setting_overrides.
+// Called at seed time to persist per-scenario config-lever values. The value
+// column is TEXT so no JSON marshalling is required.
+func (s *Store) ApplyLeverOverrides(ctx context.Context, overrides []scenariobus.SettingOverride) error {
+	if len(overrides) == 0 {
+		return nil
+	}
+
+	const q = `
+	INSERT INTO config.scenario_setting_overrides
+	    (scenario_id, key, value)
+	VALUES
+	    (:scenario_id, :key, :value)
+	ON CONFLICT (scenario_id, key) DO UPDATE
+	    SET value = EXCLUDED.value`
+
+	for _, o := range overrides {
+		row := struct {
+			ScenarioID string `db:"scenario_id"`
+			Key        string `db:"key"`
+			Value      string `db:"value"`
+		}{
+			ScenarioID: o.ScenarioID.String(),
+			Key:        o.Key,
+			Value:      o.Value,
+		}
+		if err := sqldb.NamedExecContext(ctx, s.log, s.db, q, row); err != nil {
+			return fmt.Errorf("apply lever override %s: %w", o.Key, err)
+		}
+	}
+	return nil
+}
+
+// ApplyWorkerZones updates core.users.assigned_zones for each binding.
+// Called inside the Load transaction so zone assignments are atomic with
+// fixture application. Returns an error if a username is not found.
+func (s *Store) ApplyWorkerZones(ctx context.Context, zones []scenariobus.WorkerZoneBinding) error {
+	if len(zones) == 0 {
+		return nil
+	}
+
+	const q = `
+	UPDATE core.users
+	SET    assigned_zones = :zones
+	WHERE  username = :username`
+
+	for _, z := range zones {
+		row := struct {
+			Zones    dbarray.String `db:"zones"`
+			Username string         `db:"username"`
+		}{
+			Zones:    dbarray.String(z.Zones),
+			Username: z.Username,
+		}
+		n, err := sqldb.NamedExecContextWithCount(ctx, s.log, s.db, q, row)
+		if err != nil {
+			return fmt.Errorf("apply worker zones %s: %w", z.Username, err)
+		}
+		if n == 0 {
+			return fmt.Errorf("apply worker zones: username %q not found", z.Username)
+		}
+	}
 	return nil
 }

--- a/business/domain/scenarios/scenariobus/stores/scenariodb/scenariodb.go
+++ b/business/domain/scenarios/scenariobus/stores/scenariodb/scenariodb.go
@@ -464,7 +464,7 @@ func (s *Store) ApplyWorkerZones(ctx context.Context, zones []scenariobus.Worker
 		}
 		n, err := sqldb.NamedExecContextWithCount(ctx, s.log, s.db, q, row)
 		if err != nil {
-			return fmt.Errorf("apply worker zones %s: %w", z.Username, err)
+			return fmt.Errorf("apply worker zones %q: %w", z.Username, err)
 		}
 		if n == 0 {
 			return fmt.Errorf("apply worker zones: username %q not found", z.Username)

--- a/business/domain/scenarios/scenariobus/yamlload/yamlload.go
+++ b/business/domain/scenarios/scenariobus/yamlload/yamlload.go
@@ -197,6 +197,9 @@ func (s Scenario) Validate() error {
 		if !levers.IsKnown(k) {
 			return fmt.Errorf("scenario %s: unknown lever key %q (see business/domain/config/settingsbus/levers)", s.Name, k)
 		}
+		if !levers.IsOverridable(k) {
+			return fmt.Errorf("scenario %s: lever key %q is not overridable (see business/domain/config/settingsbus/levers)", s.Name, k)
+		}
 	}
 
 	seenWorker := map[string]bool{}

--- a/business/domain/scenarios/scenariobus/yamlload/yamlload.go
+++ b/business/domain/scenarios/scenariobus/yamlload/yamlload.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 
 	"github.com/google/uuid"
+	"github.com/timmaaaz/ichor/business/domain/config/settingsbus/levers"
 	"gopkg.in/yaml.v3"
 )
 
@@ -191,6 +192,27 @@ func (s Scenario) Validate() error {
 		}
 		seenSer[sr.Ref] = true
 	}
+
+	for k := range s.LeverOverrides {
+		if !levers.IsKnown(k) {
+			return fmt.Errorf("scenario %s: unknown lever key %q (see business/domain/config/settingsbus/levers)", s.Name, k)
+		}
+	}
+
+	seenWorker := map[string]bool{}
+	for _, w := range s.Bindings.Workers {
+		if w.Username == "" {
+			return fmt.Errorf("scenario %s: worker with empty username", s.Name)
+		}
+		if len(w.Zones) == 0 {
+			return fmt.Errorf("scenario %s: worker %q has empty zones list", s.Name, w.Username)
+		}
+		if seenWorker[w.Username] {
+			return fmt.Errorf("scenario %s: duplicate worker username %q", s.Name, w.Username)
+		}
+		seenWorker[w.Username] = true
+	}
+
 	return nil
 }
 

--- a/business/domain/scenarios/scenariobus/yamlload/yamlload.go
+++ b/business/domain/scenarios/scenariobus/yamlload/yamlload.go
@@ -41,11 +41,12 @@ func IsNotFoundErr(err error) bool {
 // Scenario is the parsed + validated representation of one on-disk scenario
 // directory. Returned by Load.
 type Scenario struct {
-	ID          uuid.UUID `yaml:"id,omitempty"`
-	Name        string    `yaml:"name"`
-	Description string    `yaml:"description"`
-	Bindings    Bindings  `yaml:"-"` // loaded from bindings.yaml separately
-	State       State     `yaml:"-"` // loaded from state.yaml separately
+	ID             uuid.UUID         `yaml:"id,omitempty"`
+	Name           string            `yaml:"name"`
+	Description    string            `yaml:"description"`
+	LeverOverrides map[string]string `yaml:"lever_overrides,omitempty"`
+	Bindings       Bindings          `yaml:"-"` // loaded from bindings.yaml separately
+	State          State             `yaml:"-"` // loaded from state.yaml separately
 }
 
 // Bindings references baseline entities by stable identifier. Resolved
@@ -55,6 +56,7 @@ type Bindings struct {
 	Locations []LocationBinding `yaml:"locations"`
 	Lots      []LotBinding      `yaml:"lots"`
 	Serials   []SerialBinding   `yaml:"serials"`
+	Workers   []WorkerBinding   `yaml:"workers"`
 }
 
 type ToteBinding struct {
@@ -74,6 +76,11 @@ type LotBinding struct {
 type SerialBinding struct {
 	Ref         string `yaml:"ref"`
 	ProductCode string `yaml:"product_code"`
+}
+
+type WorkerBinding struct {
+	Username string   `yaml:"username"`
+	Zones    []string `yaml:"zones"`
 }
 
 // State is an open-shape map keyed by target-table suffix (e.g. "purchase_orders"

--- a/business/domain/scenarios/scenariobus/yamlload/yamlload_test.go
+++ b/business/domain/scenarios/scenariobus/yamlload/yamlload_test.go
@@ -182,3 +182,19 @@ func TestValidate_AcceptsKnownLeverKey(t *testing.T) {
 		t.Fatalf("Validate() = %v, want nil", err)
 	}
 }
+
+func TestValidate_RejectsNonOverridableLeverKey(t *testing.T) {
+	// pick.productScan is in KnownKeys/Defaults but locked per design doc
+	// §3.3 invariant 1 — must be rejected as a scenario override key.
+	s := yamlload.Scenario{
+		Name:           "locked-lever",
+		LeverOverrides: map[string]string{"pick.productScan": "disabled"},
+	}
+	err := s.Validate()
+	if err == nil {
+		t.Fatal("Validate() returned nil; want error for non-overridable lever key")
+	}
+	if !strings.Contains(err.Error(), "not overridable") {
+		t.Fatalf("error %q does not mention 'not overridable'", err.Error())
+	}
+}

--- a/business/domain/scenarios/scenariobus/yamlload/yamlload_test.go
+++ b/business/domain/scenarios/scenariobus/yamlload/yamlload_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/timmaaaz/ichor/business/domain/scenarios/scenariobus/yamlload"
@@ -112,5 +113,53 @@ func TestLoad_WorkersParsed(t *testing.T) {
 	}
 	if got[1].Username != "bob@example.com" || len(got[1].Zones) != 1 {
 		t.Fatalf("Workers[1] = %+v, want bob with 1 zone", got[1])
+	}
+}
+
+func TestValidate_RejectsUnknownLeverKey(t *testing.T) {
+	s := yamlload.Scenario{
+		Name:           "bad-lever",
+		LeverOverrides: map[string]string{"pick.notALever": "anything"},
+	}
+	err := s.Validate()
+	if err == nil {
+		t.Fatal("Validate() returned nil; want error for unknown lever key")
+	}
+	if !strings.Contains(err.Error(), "unknown lever key") {
+		t.Fatalf("error %q does not mention 'unknown lever key'", err.Error())
+	}
+}
+
+func TestValidate_RejectsEmptyWorkerUsername(t *testing.T) {
+	s := yamlload.Scenario{
+		Name: "bad-worker",
+		Bindings: yamlload.Bindings{
+			Workers: []yamlload.WorkerBinding{{Username: "", Zones: []string{"STG-A"}}},
+		},
+	}
+	if err := s.Validate(); err == nil {
+		t.Fatal("Validate() returned nil; want error for empty worker username")
+	}
+}
+
+func TestValidate_RejectsEmptyWorkerZones(t *testing.T) {
+	s := yamlload.Scenario{
+		Name: "bad-zones",
+		Bindings: yamlload.Bindings{
+			Workers: []yamlload.WorkerBinding{{Username: "alice", Zones: nil}},
+		},
+	}
+	if err := s.Validate(); err == nil {
+		t.Fatal("Validate() returned nil; want error for empty zones list")
+	}
+}
+
+func TestValidate_AcceptsKnownLeverKey(t *testing.T) {
+	s := yamlload.Scenario{
+		Name:           "ok",
+		LeverOverrides: map[string]string{"pick.lotScan": "required-if-lot-tracked"},
+	}
+	if err := s.Validate(); err != nil {
+		t.Fatalf("Validate() = %v, want nil", err)
 	}
 }

--- a/business/domain/scenarios/scenariobus/yamlload/yamlload_test.go
+++ b/business/domain/scenarios/scenariobus/yamlload/yamlload_test.go
@@ -154,6 +154,25 @@ func TestValidate_RejectsEmptyWorkerZones(t *testing.T) {
 	}
 }
 
+func TestValidate_RejectsDuplicateWorkerUsername(t *testing.T) {
+	s := yamlload.Scenario{
+		Name: "dup-worker",
+		Bindings: yamlload.Bindings{
+			Workers: []yamlload.WorkerBinding{
+				{Username: "alice@example.com", Zones: []string{"STG-A"}},
+				{Username: "alice@example.com", Zones: []string{"PCK"}},
+			},
+		},
+	}
+	err := s.Validate()
+	if err == nil {
+		t.Fatal("Validate() returned nil; want error for duplicate worker username")
+	}
+	if !strings.Contains(err.Error(), "duplicate worker username") {
+		t.Fatalf("error %q does not mention 'duplicate worker username'", err.Error())
+	}
+}
+
 func TestValidate_AcceptsKnownLeverKey(t *testing.T) {
 	s := yamlload.Scenario{
 		Name:           "ok",

--- a/business/domain/scenarios/scenariobus/yamlload/yamlload_test.go
+++ b/business/domain/scenarios/scenariobus/yamlload/yamlload_test.go
@@ -1,7 +1,9 @@
 package yamlload_test
 
 import (
+	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/timmaaaz/ichor/business/domain/scenarios/scenariobus/yamlload"
@@ -50,5 +52,62 @@ func TestValidate_DuplicateBindingRef(t *testing.T) {
 	err := s.Validate()
 	if err == nil {
 		t.Fatal("expected validation error for duplicate lot ref")
+	}
+}
+
+func Test_Load_LeverOverrides_Parsed(t *testing.T) {
+	dir := t.TempDir()
+	scenarioDir := filepath.Join(dir, "with-overrides")
+	if err := os.MkdirAll(scenarioDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(scenarioDir, "scenario.yaml"),
+		[]byte("name: with-overrides\nlever_overrides:\n  pick.lotScan: required-if-lot-tracked\n  pick.destinationScan: required\n"),
+		0o644); err != nil {
+		t.Fatalf("write scenario.yaml: %v", err)
+	}
+
+	scenarios, err := yamlload.Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(scenarios) != 1 {
+		t.Fatalf("got %d scenarios, want 1", len(scenarios))
+	}
+	got := scenarios[0].LeverOverrides
+	if want := map[string]string{
+		"pick.lotScan":         "required-if-lot-tracked",
+		"pick.destinationScan": "required",
+	}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("LeverOverrides = %v, want %v", got, want)
+	}
+}
+
+func Test_Load_Workers_Parsed(t *testing.T) {
+	dir := t.TempDir()
+	scenarioDir := filepath.Join(dir, "with-workers")
+	if err := os.MkdirAll(scenarioDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(scenarioDir, "scenario.yaml"),
+		[]byte("name: with-workers\n"), 0o644); err != nil {
+		t.Fatalf("write scenario.yaml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(scenarioDir, "bindings.yaml"),
+		[]byte("workers:\n  - username: alice@example.com\n    zones: [STG-A, STG-B]\n  - username: bob@example.com\n    zones: [PCK]\n"),
+		0o644); err != nil {
+		t.Fatalf("write bindings.yaml: %v", err)
+	}
+
+	scenarios, err := yamlload.Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	got := scenarios[0].Bindings.Workers
+	if len(got) != 2 {
+		t.Fatalf("Workers len = %d, want 2", len(got))
+	}
+	if got[0].Username != "alice@example.com" || len(got[0].Zones) != 2 {
+		t.Fatalf("Workers[0] = %+v, want alice with 2 zones", got[0])
 	}
 }

--- a/business/domain/scenarios/scenariobus/yamlload/yamlload_test.go
+++ b/business/domain/scenarios/scenariobus/yamlload/yamlload_test.go
@@ -55,7 +55,7 @@ func TestValidate_DuplicateBindingRef(t *testing.T) {
 	}
 }
 
-func Test_Load_LeverOverrides_Parsed(t *testing.T) {
+func TestLoad_LeverOverridesParsed(t *testing.T) {
 	dir := t.TempDir()
 	scenarioDir := filepath.Join(dir, "with-overrides")
 	if err := os.MkdirAll(scenarioDir, 0o755); err != nil {
@@ -83,7 +83,7 @@ func Test_Load_LeverOverrides_Parsed(t *testing.T) {
 	}
 }
 
-func Test_Load_Workers_Parsed(t *testing.T) {
+func TestLoad_WorkersParsed(t *testing.T) {
 	dir := t.TempDir()
 	scenarioDir := filepath.Join(dir, "with-workers")
 	if err := os.MkdirAll(scenarioDir, 0o755); err != nil {
@@ -109,5 +109,8 @@ func Test_Load_Workers_Parsed(t *testing.T) {
 	}
 	if got[0].Username != "alice@example.com" || len(got[0].Zones) != 2 {
 		t.Fatalf("Workers[0] = %+v, want alice with 2 zones", got[0])
+	}
+	if got[1].Username != "bob@example.com" || len(got[1].Zones) != 1 {
+		t.Fatalf("Workers[1] = %+v, want bob with 1 zone", got[1])
 	}
 }

--- a/business/sdk/dbtest/dbtest.go
+++ b/business/sdk/dbtest/dbtest.go
@@ -175,6 +175,8 @@ import (
 	"github.com/timmaaaz/ichor/business/domain/config/pageconfigbus/stores/pageconfigdb"
 	"github.com/timmaaaz/ichor/business/domain/config/pagecontentbus"
 	"github.com/timmaaaz/ichor/business/domain/config/pagecontentbus/stores/pagecontentdb"
+	"github.com/timmaaaz/ichor/business/domain/config/settingsbus"
+	"github.com/timmaaaz/ichor/business/domain/config/settingsbus/stores/settingsdb"
 
 	"github.com/timmaaaz/ichor/business/sdk/delegate"
 	"github.com/timmaaaz/ichor/business/sdk/migrate"
@@ -310,6 +312,7 @@ type BusDomain struct {
 	PageAction  *pageactionbus.Business
 	PageConfig  *pageconfigbus.Business
 	PageContent *pagecontentbus.Business
+	Settings    *settingsbus.Business
 }
 
 func newBusDomains(log *logger.Logger, db *sqlx.DB) BusDomain {
@@ -435,6 +438,7 @@ func newBusDomains(log *logger.Logger, db *sqlx.DB) BusDomain {
 	pageContentBus := pagecontentbus.NewBusiness(log, delegate, pagecontentdb.NewStore(log, db))
 	pageActionBus := pageactionbus.NewBusiness(log, delegate, pageactiondb.NewStore(log, db))
 	pageConfigBus := pageconfigbus.NewBusiness(log, delegate, pageconfigdb.NewStore(log, db), pageContentBus, pageActionBus)
+	settingsBus := settingsbus.NewBusiness(log, delegate, settingsdb.NewStore(log, db))
 
 	return BusDomain{
 		Delegate:                    delegate,
@@ -518,6 +522,7 @@ func newBusDomains(log *logger.Logger, db *sqlx.DB) BusDomain {
 		PageAction:                  pageActionBus,
 		PageConfig:                  pageConfigBus,
 		PageContent:                 pageContentBus,
+		Settings:                    settingsBus,
 	}
 
 }

--- a/business/sdk/dbtest/dbtest.go
+++ b/business/sdk/dbtest/dbtest.go
@@ -414,7 +414,9 @@ func newBusDomains(log *logger.Logger, db *sqlx.DB) BusDomain {
 	labelBus := labelbus.NewBusiness(log, delegate, labeldb.NewStore(log, db), nil)
 
 	// Scenarios — beginner is required for transactional Load/Reset.
-	scenarioBus := scenariobus.NewBusiness(log, delegate, scenariodb.NewStore(log, db), sqldb.NewBeginner(db))
+	// Pass "" for scenariosRoot: dbtest contexts do not exercise the YAML
+	// worker-zone path.
+	scenarioBus := scenariobus.NewBusiness(log, delegate, scenariodb.NewStore(log, db), sqldb.NewBeginner(db), "")
 
 	// Orders
 	orderFulfillmentStatusBus := orderfulfillmentstatusbus.NewBusiness(log, delegate, orderfulfillmentstatusdb.NewStore(log, db))

--- a/business/sdk/dbtest/seedFrontend.go
+++ b/business/sdk/dbtest/seedFrontend.go
@@ -118,6 +118,12 @@ func InsertSeedDataWithDB(log *logger.Logger, db *sqlx.DB) error {
 		return fmt.Errorf("seeding approvals: %w", err)
 	}
 
+	// Phase 0g.B5 — settings must exist before scenarios can reference
+	// them via lever_overrides; semantic ordering even though no FK enforces it.
+	if err := seedSettings(ctx, busDomain); err != nil {
+		return fmt.Errorf("seeding settings: %w", err)
+	}
+
 	if err := seedScenarios(ctx, busDomain); err != nil {
 		return fmt.Errorf("seeding scenarios: %w", err)
 	}

--- a/business/sdk/dbtest/seed_integration_test.go
+++ b/business/sdk/dbtest/seed_integration_test.go
@@ -2,10 +2,14 @@ package dbtest
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
+	"github.com/timmaaaz/ichor/business/domain/config/settingsbus"
+	"github.com/timmaaaz/ichor/business/domain/config/settingsbus/levers"
 	"github.com/timmaaaz/ichor/business/domain/labels/labelbus"
 	"github.com/timmaaaz/ichor/business/domain/products/productbus"
+	"github.com/timmaaaz/ichor/business/sdk/order"
 	"github.com/timmaaaz/ichor/business/sdk/page"
 )
 
@@ -93,5 +97,39 @@ func Test_Seed_Integration(t *testing.T) {
 	}
 	if len(zonedC) < 1 {
 		t.Errorf("expected ≥1 user assigned to STG-C, got %d", len(zonedC))
+	}
+
+	// --- Phase 0g.B5 — assert 11 lever defaults present --------------------
+	leverRows, err := db.BusDomain.Settings.Query(ctx, settingsbus.QueryFilter{}, order.NewBy(settingsbus.OrderByKey, order.ASC), page.MustParse("1", "100"))
+	if err != nil {
+		t.Fatalf("query settings: %v", err)
+	}
+
+	wantKeys := map[string]string{}
+	for _, k := range levers.KnownKeys {
+		wantKeys[k] = levers.Defaults[k]
+	}
+
+	gotKeys := map[string]string{}
+	for _, s := range leverRows {
+		if _, isLever := wantKeys[s.Key]; !isLever {
+			continue
+		}
+		var v string
+		if err := json.Unmarshal(s.Value, &v); err != nil {
+			t.Fatalf("unmarshal value for %q: %v", s.Key, err)
+		}
+		gotKeys[s.Key] = v
+	}
+
+	for k, want := range wantKeys {
+		got, ok := gotKeys[k]
+		if !ok {
+			t.Errorf("missing lever key %q in config.settings after reseed", k)
+			continue
+		}
+		if got != want {
+			t.Errorf("lever %q value: got %q, want %q", k, got, want)
+		}
 	}
 }

--- a/business/sdk/dbtest/seed_integration_test.go
+++ b/business/sdk/dbtest/seed_integration_test.go
@@ -112,6 +112,9 @@ func Test_Seed_Integration(t *testing.T) {
 
 	gotKeys := map[string]string{}
 	for _, s := range leverRows {
+		// migrate.sql v2.01 pre-seeds non-lever numeric rows (e.g.
+		// inventory.variance_threshold_units = 5) that would panic the
+		// string unmarshal below. Skip anything not in the lever set.
 		if _, isLever := wantKeys[s.Key]; !isLever {
 			continue
 		}

--- a/business/sdk/dbtest/seed_scenarios.go
+++ b/business/sdk/dbtest/seed_scenarios.go
@@ -52,6 +52,11 @@ func seedScenarios(ctx context.Context, busDomain BusDomain) error {
 			return fmt.Errorf("seed scenario %s: %w", s.Name, err)
 		}
 
+		// Phase 0g.B5 — mirror lever_overrides into config.scenario_setting_overrides.
+		if err := busDomain.Scenario.SeedApplyLeverOverrides(ctx, s.ID, s.LeverOverrides); err != nil {
+			return fmt.Errorf("seed scenario %s: lever overrides: %w", s.Name, err)
+		}
+
 		// Sort state keys so fixture insertion order is deterministic.
 		// Go map iteration is randomized; sorted iteration plus slice-ordered
 		// rows keeps UUIDs and row identities stable across reseeds.

--- a/business/sdk/dbtest/seed_scenarios.go
+++ b/business/sdk/dbtest/seed_scenarios.go
@@ -28,7 +28,16 @@ func seedScenarios(ctx context.Context, busDomain BusDomain) error {
 		return fmt.Errorf("find repo root: %w", err)
 	}
 	scenariosDir := filepath.Join(root, "deployments", "scenarios")
+	return SeedScenariosFromRoot(ctx, busDomain, scenariosDir)
+}
 
+// SeedScenariosFromRoot seeds scenarios from an explicit root directory.
+// It is the workhorse called by seedScenarios (which computes the root via
+// findRepoRoot) and by integration tests that need to seed from a t.TempDir().
+//
+// NotFoundErr from yamlload.Load is silently ignored — callers that pass an
+// empty temp dir or a path with no scenario subdirectories are not an error.
+func SeedScenariosFromRoot(ctx context.Context, busDomain BusDomain, scenariosDir string) error {
 	scenarios, err := yamlload.Load(scenariosDir)
 	if err != nil {
 		if yamlload.IsNotFoundErr(err) {

--- a/business/sdk/dbtest/seed_settings.go
+++ b/business/sdk/dbtest/seed_settings.go
@@ -1,0 +1,36 @@
+package dbtest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/timmaaaz/ichor/business/domain/config/settingsbus"
+	"github.com/timmaaaz/ichor/business/domain/config/settingsbus/levers"
+)
+
+// seedSettings inserts the 11 SMB-default lever keys into config.settings.
+// Called from seedFrontend.go BEFORE seedScenarios so scenarios that
+// reference these keys via lever_overrides have something to override.
+//
+// Idempotency: settingsbus.Create returns ErrUniqueEntry on duplicate key.
+// We treat that as success because make reseed-frontend wipes the DB
+// before re-running, so a duplicate at this point would mean two callers
+// in the same chain — a developer error worth surfacing.
+func seedSettings(ctx context.Context, busDomain BusDomain) error {
+	for _, key := range levers.KnownKeys {
+		raw, err := json.Marshal(levers.Defaults[key])
+		if err != nil {
+			return fmt.Errorf("seed setting marshal %s: %w", key, err)
+		}
+		ns := settingsbus.NewSetting{
+			Key:         key,
+			Value:       json.RawMessage(raw),
+			Description: "Phase 0g.B5 lever — see design doc 2026-04-24 §3.3",
+		}
+		if _, err := busDomain.Settings.Create(ctx, ns); err != nil {
+			return fmt.Errorf("seed setting %s: %w", key, err)
+		}
+	}
+	return nil
+}

--- a/business/sdk/dbtest/seed_settings.go
+++ b/business/sdk/dbtest/seed_settings.go
@@ -14,9 +14,10 @@ import (
 // reference these keys via lever_overrides have something to override.
 //
 // Idempotency: settingsbus.Create returns ErrUniqueEntry on duplicate key.
-// We treat that as success because make reseed-frontend wipes the DB
-// before re-running, so a duplicate at this point would mean two callers
-// in the same chain — a developer error worth surfacing.
+// We surface that as a fatal error rather than swallowing it: make
+// reseed-frontend wipes the DB before re-running, so a duplicate at this
+// point would mean two callers in the same chain — a developer error
+// worth surfacing.
 func seedSettings(ctx context.Context, busDomain BusDomain) error {
 	for _, key := range levers.KnownKeys {
 		raw, err := json.Marshal(levers.Defaults[key])

--- a/deployments/scenarios/_schema.yaml
+++ b/deployments/scenarios/_schema.yaml
@@ -15,6 +15,14 @@
 #   name        string, required. Scenario identifier — used in URLs and as the
 #               YAML key. Must be unique across all scenarios.
 #   description string, optional. Human-readable summary.
+#   lever_overrides
+#               map[string]string, optional. Per-scenario overrides for
+#               scan-discipline lever keys. Keys must be in the canonical
+#               set (see business/domain/config/settingsbus/levers/levers.go
+#               for the 11 supported keys; design doc 2026-04-24 §3.3 for
+#               semantics). Values are free-form strings consumed by the
+#               settings resolver. Mirrored into config.scenario_setting_overrides
+#               at seed time; settings GET returns the merged view.
 #
 # bindings.yaml:
 #   totes     list of {code: string}
@@ -26,6 +34,13 @@
 #                                  within this scenario's state.yaml FKs
 #   serials   list of {ref: string, product_code: string}
 #                                  same pattern for serial numbers
+#   workers   list of {username: string, zones: [string]}
+#                                  scenario-scoped worker→zone assignments.
+#                                  Applied at scenariobus.Load time as
+#                                  UPDATE core.users SET assigned_zones=zones
+#                                  WHERE username=username. Used by zone-sliced
+#                                  pick (lever pick.assignmentGranularity =
+#                                  zone-sliced-order).
 #
 # state.yaml:
 #   Keyed by target-table suffix (e.g. purchase_orders, inventory_items,

--- a/docs/arch/seeding.md
+++ b/docs/arch/seeding.md
@@ -237,7 +237,7 @@ ContactInfos, Customers, Currency, Order, OrderLineItem
 OrderFulfillmentStatus, LineItemFulfillmentStatus
 
 // Config
-ConfigStore, TableStore, Form, FormField
+ConfigStore, TableStore, Form, FormField, Settings
 PageAction, PageConfig, PageContent
 
 // Workflow
@@ -245,6 +245,9 @@ Workflow, Alert, Notification, ApprovalRequest
 
 // Inventory (cycle counts)
 CycleCountSession, CycleCountItem
+
+// Scenarios
+Scenario
 ```
 
 ---
@@ -297,6 +300,10 @@ seedAlerts(ctx, log, busDomain, adminID)
 seedCycleCounts(ctx, busDomain, foundation, products, inventory)
     ↓
 seedApprovals(ctx, busDomain, foundation)                         → queries rules from seedWorkflow
+    ↓
+seedSettings(ctx, busDomain)                                      → 11 scan-discipline lever rows
+    ↓
+seedScenarios(ctx, busDomain)                                     → loads YAML fixtures from deployments/scenarios
 ```
 
 `adminID` is extracted from `foundation.Admins[0].ID` after `seedFoundation`.
@@ -446,6 +453,29 @@ func seedApprovals(ctx context.Context, busDomain BusDomain, foundation Foundati
 ```
 Seeds: 5 automation executions (FK prerequisite) + 5 pending approval requests.
 Must run after seedWorkflow — queries rules from DB.
+
+### seed_settings.go
+```go
+func seedSettings(ctx context.Context, busDomain BusDomain) error
+```
+Seeds: 11 canonical scan-discipline lever rows from `levers.Defaults`
+(`business/domain/config/settingsbus/levers`). Single source of truth
+for default lever values; scenarios may override individual keys via
+`config.scenario_setting_overrides`. Must run before seedScenarios so
+each override has a base row for the settings GET LEFT JOIN to merge
+(semantic ordering; no FK enforces it).
+
+### seed_scenarios.go
+```go
+func seedScenarios(ctx context.Context, busDomain BusDomain) error
+func SeedScenariosFromRoot(ctx context.Context, busDomain BusDomain, scenariosDir string) error
+```
+Seeds: scenarios + scenario_fixtures rows from YAML files under
+`deployments/scenarios/`. `seedScenarios` discovers the root via
+`findRepoRoot()` (private, walks for go.mod); `SeedScenariosFromRoot`
+takes an explicit path so integration tests can point at a temp dir.
+Must run last — depends on every preceding seeder for FK references
+(products, locations, totes) resolved by `seed_scenarios_refs.go`.
 
 ---
 


### PR DESCRIPTION
## Summary

- Seeds 11 default scan-discipline lever keys into `config.settings` (per design doc 2026-04-24 §3.3, single-source-of-truth via `business/domain/config/settingsbus/levers`).
- Extends scenario YAML schema with `lever_overrides` (top-level) and `workers` (bindings.yaml block); `yamlload.Validate` rejects unknown keys + malformed worker entries.
- Mirrors `lever_overrides` into `config.scenario_setting_overrides` at seed time via `Storer.ApplyLeverOverrides` (UPSERT on PK `(scenario_id, key)`).
- Applies worker→zone bindings to `core.users.assigned_zones` inside the `scenariobus.Load` transaction via `Storer.ApplyWorkerZones`. Re-reads `bindings.yaml` at Load time (architectural decision: not persisted; see plan §Architecture deviation 1).
- Extends `settingsdb.Query` and `QueryByKey` with a `LEFT JOIN scenarios_active LEFT JOIN scenario_setting_overrides`, using a `CASE` form for the type-bridge (`config.settings.value` is jsonb, `scenario_setting_overrides.value` is text → wraps via `to_jsonb(o.value)` only when the override exists, falling through to base via SQL-NULL check).

## Closes

- **GAPS B-12, B-13, B-14** (per Task 1 verification on `github/master`: zero pre-existing references to lever keys, `lever_overrides`, or worker-binding types in the scenario subsystem).
- **Phase 0g.B5** sub-phase. Tier 1 close: this is the third of three Tier 1 tracks (B1 already merged in `cac2085c`; B3 expected to merge in parallel). Tier 2 (F1, F3) unblocks once both B5 and B3 merge.

## Test plan

- [x] `go test ./business/domain/config/settingsbus/levers/...` — registry invariants (11 keys, sort order, `pick.productScan` always required)
- [x] `go test ./business/domain/scenarios/scenariobus/yamlload/...` — parse + validate (8 tests)
- [x] `go test ./business/domain/scenarios/scenariobus/...` — Load integration with overrides + workers + Reset round-trip (Docker, ~16s)
- [x] `go test ./business/sdk/dbtest/... -run Test_Seed_Integration` — reseed assertion includes 11 lever rows
- [x] `go test ./api/cmd/services/ichor/tests/scenarios/...` — POST load + GET settings reflects override (20/20 pass, real HTTP, ~3.8s)
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] DoD greps: 22 lever-key strings in `levers.go` (11 KnownKeys + 11 Defaults); seed_settings.go correctly references `levers.KnownKeys` (single source of truth)

## Architecture deviations (already approved)

1. `lever_overrides` written at seed time (not runtime DELETE+INSERT) — settings GET resolves merged view via LEFT JOIN.
2. `worker_zone_ref` NOT added to `seed_scenarios_refs.knownRefSuffixes` — bindings.yaml#workers applied at Load via `Storer.ApplyWorkerZones`.
3. Switch-scenario zone-leak limitation accepted — `assigned_zones` from outgoing scenario persist for users not in incoming scenario; mitigation = disjoint user sets in Phase 1 dogfood.

## Follow-ups (NOT blockers; tracked in NOTES.md)

- **Phase 1 prod-container `scenariosRoot` discovery:** `FindScenariosRoot` walks for `go.mod`, which won't be present in containerized prod. Fallback log-and-continues with `scenariosRoot = ""` (worker zones silently disabled). Need a `cfg.ScenariosRoot` env-var override before Phase 1 dogfood lands in containers.
- **`InsertPlatformConfig` lever seeding:** the platform-config-only bootstrap path doesn't seed levers; an operator running `InsertPlatformConfig` then activating a scenario gets empty merged settings. One-line follow-up.
- **`readWorkerZonesForScenario` scaling:** parses every scenario directory on every Load (O(n) FS reads). Acceptable at current scale (1-3 scenarios); revisit at 50+.

## Notes

- Plan: `docs/superpowers/plans/floor-physical-warehouse-testing/phase-0g-b5-config-levers.md` (1784 lines, 17 tasks, gitignored)
- Per-task two-tier review (spec compliance + code quality) ran on every commit; comprehensive in-session review just completed (Approved-with-minors, none blocking).
- Type-bridge between `config.settings.value` (jsonb) and `config.scenario_setting_overrides.value` (text) was a non-obvious trap that required `CASE WHEN o.value IS NOT NULL THEN to_jsonb(o.value) ELSE s.value END` rather than the plan-literal `COALESCE(to_jsonb(o.value), s.value)` (which would mask base values with jsonb-null when no override exists). Comments at `settingsdb.go:88-91, 159-162` document this.