### PR TITLE
fix(dbtest): seed levers in InsertPlatformConfig (B5 follow-up I1)

### DIFF
--- a/business/sdk/dbtest/seedFrontend.go
+++ b/business/sdk/dbtest/seedFrontend.go
@@ -167,5 +167,13 @@ func InsertPlatformConfig(log *logger.Logger, cfg sqldb.Config) error {
 		return fmt.Errorf("seeding alerts: %w", err)
 	}
 
+	// Phase 0g.B5 follow-up — bootstrap-path lever defaults. Mirrors the
+	// InsertSeedDataWithDB call site so customer-bootstrapped DBs have the
+	// 11 lever rows populated in config.settings; without this, the
+	// settingsdb merge LEFT JOIN returns no rows for any lever key.
+	if err := seedSettings(ctx, busDomain); err != nil {
+		return fmt.Errorf("seeding settings: %w", err)
+	}
+
 	return nil
 }

--- a/docs/arch/seeding.md
+++ b/docs/arch/seeding.md
@@ -190,8 +190,8 @@ key facts:
   - TimeZone: `SET TIME ZONE 'America/New_York'`
   - Runs migrations + seeds before returning
   - Each test gets its own isolated database instance
-  - Two seeding entry points: InsertSeedData (live K8s/Docker DB for `make seed-frontend`) + NewDatabase (isolated test DB)
-  - Both use the same BusDomain struct and same seed_*.go chain
+  - Three seeding entry points: InsertSeedData (live K8s/Docker DB for `make seed-frontend`), NewDatabase (isolated test DB), and InsertPlatformConfig (`make seed-platform` — fresh customer DB bootstrap, platform config only, no demo data)
+  - All use the same BusDomain struct and same seed_*.go functions
 
 ---
 
@@ -307,6 +307,38 @@ seedScenarios(ctx, busDomain)                                     → loads YAML
 ```
 
 `adminID` is extracted from `foundation.Admins[0].ID` after `seedFoundation`.
+
+---
+
+## InsertPlatformConfig [dbtest]
+
+file: business/sdk/dbtest/seedFrontend.go (`InsertPlatformConfig`)
+
+```go
+func InsertPlatformConfig(log *logger.Logger, cfg sqldb.Config) error
+```
+
+Subset of the orchestrator above. Used by `make seed-platform` (sole caller: `api/cmd/tooling/admin/commands/seedPlatform.go`) to bootstrap a fresh customer DB with **platform configuration only** — no demo users, products, orders, or inventory. Requires migrations + `seed.sql` (admin_gopher) to have run first.
+
+Chain (execution order is authoritative — do not reorder):
+
+```
+seedTableBuilder(ctx, busDomain, adminID)
+    ↓
+seedPages(ctx, log, busDomain)
+    ↓
+seedForms(ctx, log, busDomain, db)
+    ↓
+seedWorkflow(ctx, log, busDomain, adminID)
+    ↓
+seedAlerts(ctx, log, busDomain, adminID)
+    ↓
+seedSettings(ctx, busDomain)                                      → 11 scan-discipline lever rows
+```
+
+`adminID` is hardcoded to `5cf37266-3473-4006-984f-9325122678b7` (admin_gopher from `seed.sql`) — no `seedFoundation` runs in this path.
+
+⚠ **Not idempotent.** `seedSettings` (and other seeders) call `Create` directly with no upsert; running `make seed-platform` twice against the same DB fails on `ErrUniqueEntry`. Operators must wipe the DB before re-running.
 
 ---
 

--- a/docs/arch/seeding.md
+++ b/docs/arch/seeding.md
@@ -222,6 +222,9 @@ AssetType, AssetCondition, UserAsset, Asset
 // Products
 Brand, ProductCategory, Product, ProductUOM, PhysicalAttribute, ProductCost, Metrics, CostHistory
 
+// Labels
+Label
+
 // Procurement
 Supplier, SupplierProduct, PaymentTerm
 PurchaseOrderStatus, PurchaseOrderLineItemStatus, PurchaseOrder, PurchaseOrderLineItem
@@ -291,7 +294,7 @@ seedTableBuilder(ctx, busDomain, adminID)
     ↓
 seedPages(ctx, log, busDomain)
     ↓
-seedForms(ctx, log, busDomain)
+seedForms(ctx, log, busDomain, db)
     ↓
 seedWorkflow(ctx, log, busDomain, adminID)
     ↓
@@ -301,7 +304,7 @@ seedCycleCounts(ctx, busDomain, foundation, products, inventory)
     ↓
 seedApprovals(ctx, busDomain, foundation)                         → queries rules from seedWorkflow
     ↓
-seedSettings(ctx, busDomain)                                      → 11 scan-discipline lever rows
+seedSettings(ctx, busDomain)                                      → 11 scan-discipline lever rows (pick.productScan locked; 10 overridable by scenarios)
     ↓
 seedScenarios(ctx, busDomain)                                     → loads YAML fixtures from deployments/scenarios
 ```
@@ -333,10 +336,12 @@ seedWorkflow(ctx, log, busDomain, adminID)
     ↓
 seedAlerts(ctx, log, busDomain, adminID)
     ↓
-seedSettings(ctx, busDomain)                                      → 11 scan-discipline lever rows
+seedSettings(ctx, busDomain)                                      → 11 scan-discipline lever rows (pick.productScan locked; 10 overridable by scenarios)
 ```
 
 `adminID` is hardcoded to `5cf37266-3473-4006-984f-9325122678b7` (admin_gopher from `seed.sql`) — no `seedFoundation` runs in this path.
+
+`seedScenarios` is intentionally omitted — `make seed-platform` is the customer-bootstrap path, not a demo/test seed. Customers load scenarios on demand via the scenarios admin UI / `POST /v1/scenarios/{id}/load`, which writes to the `seedSettings`-seeded base rows via `lever_overrides`.
 
 ⚠ **Not idempotent.** `seedSettings` (and other seeders) call `Create` directly with no upsert; running `make seed-platform` twice against the same DB fails on `ErrUniqueEntry`. Operators must wipe the DB before re-running.
 
@@ -453,7 +458,7 @@ References `seedmodels/pageactions.go` and `seedmodels/pages.go`.
 
 ### seed_forms.go
 ```go
-func seedForms(ctx context.Context, log *logger.Logger, busDomain BusDomain) error
+func seedForms(ctx context.Context, log *logger.Logger, busDomain BusDomain, db *sqlx.DB) error
 ```
 Seeds: forms and all form fields.
 key facts:
@@ -496,6 +501,11 @@ for default lever values; scenarios may override individual keys via
 `config.scenario_setting_overrides`. Must run before seedScenarios so
 each override has a base row for the settings GET LEFT JOIN to merge
 (semantic ordering; no FK enforces it).
+
+⚠ **`pick.productScan` is non-overridable** — listed in `levers.nonOverridableKeys`
+per design doc §3.3 invariant 1 (always `"required"`). It is still seeded as one
+of the 11 base rows but `levers.IsOverridable` rejects it from any scenario's
+`lever_overrides`. Of the 11 seeded keys, 10 are overridable.
 
 ### seed_scenarios.go
 ```go


### PR DESCRIPTION
## Summary

Phase 0g.B5 wired `seedSettings` into `InsertSeedDataWithDB` (the dogfood seed entry point) but missed the parallel `InsertPlatformConfig` path used to bootstrap a new customer DB. Without this, an operator running `InsertPlatformConfig` and then activating a scenario gets empty `config.settings` rows; the settings GET LEFT JOIN returns no rows for any lever key.

## Closes

- **I1** (B5 NOTES.md backlog) — InsertPlatformConfig lever-seeding gap

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./business/sdk/dbtest/...` clean
- [x] `go test ./business/sdk/dbtest/... -run Test_Seed_Integration` — PASS (existing 11-lever-keys assertion continues to validate the dogfood path)

## Notes

The fix mirrors B5's existing wire-up in `InsertSeedDataWithDB`. No new tests added — the existing integration test already covers the `seedSettings` function; this PR adds a second call site to the same well-tested function. Customer-bootstrap path coverage is left as future test infrastructure work if `InsertPlatformConfig` ever gains a dedicated integration test harness.