### PR TITLE
phase-0g.B6: seed 6 additional lever keys (cycleCount, adjustment, putaway, inspection)

### DIFF
--- a/business/domain/config/settingsbus/levers/levers.go
+++ b/business/domain/config/settingsbus/levers/levers.go
@@ -9,12 +9,18 @@ package levers
 // KnownKeys is the complete, sorted list of lever keys. Sorted to
 // stabilize seed insert order and test diff output.
 var KnownKeys = []string{
+	"adjustment.locationScan",
+	"cycleCount.locationScan",
+	"inspection.lotScan",
 	"pick.assignmentGranularity",
 	"pick.destinationMode",
 	"pick.destinationScan",
 	"pick.lotScan",
 	"pick.productScan",
 	"pick.sourceLocationScan",
+	"putaway.destinationLocationScan",
+	"putaway.itemScan",
+	"putaway.lotScan",
 	"receive.expiryCapture",
 	"receive.lotCapture",
 	"receive.poScan",
@@ -27,17 +33,23 @@ var KnownKeys = []string{
 // not exposed as a configurable lever — included here for resolver
 // completeness, NOT for customer override.
 var Defaults = map[string]string{
-	"pick.assignmentGranularity":  "whole-order",
-	"pick.destinationMode":        "direct-stage",
-	"pick.destinationScan":        "button-confirm",
-	"pick.lotScan":                "disabled",
-	"pick.productScan":            "required",
-	"pick.sourceLocationScan":     "button-confirm",
-	"receive.expiryCapture":       "required-if-lot-tracked",
-	"receive.lotCapture":          "required-if-lot-tracked",
-	"receive.poScan":              "required",
-	"transfer.destinationScan":    "button-confirm",
-	"transfer.sourceLocationScan": "button-confirm",
+	"adjustment.locationScan":         "required",
+	"cycleCount.locationScan":         "required",
+	"inspection.lotScan":              "disabled",
+	"pick.assignmentGranularity":      "whole-order",
+	"pick.destinationMode":            "direct-stage",
+	"pick.destinationScan":            "button-confirm",
+	"pick.lotScan":                    "disabled",
+	"pick.productScan":                "required",
+	"pick.sourceLocationScan":         "button-confirm",
+	"putaway.destinationLocationScan": "required",
+	"putaway.itemScan":                "required",
+	"putaway.lotScan":                 "disabled",
+	"receive.expiryCapture":           "required-if-lot-tracked",
+	"receive.lotCapture":              "required-if-lot-tracked",
+	"receive.poScan":                  "required",
+	"transfer.destinationScan":        "button-confirm",
+	"transfer.sourceLocationScan":     "button-confirm",
 }
 
 // IsKnown reports whether key is one of the canonical lever keys. Used by

--- a/business/domain/config/settingsbus/levers/levers_test.go
+++ b/business/domain/config/settingsbus/levers/levers_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/timmaaaz/ichor/business/domain/config/settingsbus/levers"
 )
 
-func Test_Defaults_HasExactlyElevenKeys(t *testing.T) {
-	if got, want := len(levers.Defaults), 11; got != want {
+func Test_Defaults_HasExactlySeventeenKeys(t *testing.T) {
+	if got, want := len(levers.Defaults), 17; got != want {
 		t.Fatalf("len(Defaults) = %d, want %d", got, want)
 	}
 }

--- a/business/domain/scenarios/scenariobus/scenariobus_load_test.go
+++ b/business/domain/scenarios/scenariobus/scenariobus_load_test.go
@@ -27,7 +27,7 @@ func Test_Load_AppliesLeverOverrides_AndWorkerZones(t *testing.T) {
 	db := dbtest.NewDatabase(t, "Test_Load_AppliesLeverOverrides_AndWorkerZones")
 	ctx := context.Background()
 
-	// Baseline seed — populates config.settings (11 levers) plus all FK
+	// Baseline seed — populates config.settings (17 levers) plus all FK
 	// dependencies required by the user bus.
 	if err := dbtest.InsertSeedDataWithDB(db.Log, db.DB); err != nil {
 		t.Fatalf("baseline seed: %v", err)
@@ -48,7 +48,7 @@ func Test_Load_AppliesLeverOverrides_AndWorkerZones(t *testing.T) {
 		t.Fatalf("mkdir scenario dir: %v", err)
 	}
 
-	scenarioYAML := "name: test-levers\ndescription: B5 integration test\nlever_overrides:\n  pick.lotScan: required-if-lot-tracked\n  pick.destinationScan: required\n"
+	scenarioYAML := "name: test-levers\ndescription: B5 + B6 integration test\nlever_overrides:\n  pick.lotScan: required-if-lot-tracked\n  pick.destinationScan: required\n  cycleCount.locationScan: button-confirm\n"
 	if err := os.WriteFile(filepath.Join(scenarioDir, "scenario.yaml"), []byte(scenarioYAML), 0o644); err != nil {
 		t.Fatalf("write scenario.yaml: %v", err)
 	}
@@ -98,6 +98,20 @@ func Test_Load_AppliesLeverOverrides_AndWorkerZones(t *testing.T) {
 	}
 	if lotScanValue != "required-if-lot-tracked" {
 		t.Errorf("pick.lotScan = %q, want %q (override should win)", lotScanValue, "required-if-lot-tracked")
+	}
+
+	// Assert: B6 new-lever override visible.
+	// cycleCount.locationScan default is "required"; override must win.
+	cycleCountSetting, err := db.BusDomain.Settings.QueryByKey(ctx, "cycleCount.locationScan")
+	if err != nil {
+		t.Fatalf("query cycleCount.locationScan: %v", err)
+	}
+	var cycleCountValue string
+	if err := json.Unmarshal(cycleCountSetting.Value, &cycleCountValue); err != nil {
+		t.Fatalf("unmarshal cycleCount.locationScan value: %v", err)
+	}
+	if cycleCountValue != "button-confirm" {
+		t.Errorf("cycleCount.locationScan = %q, want %q (override should win)", cycleCountValue, "button-confirm")
 	}
 
 	// Assert: non-overridden key returns base default.
@@ -152,6 +166,19 @@ func Test_Load_AppliesLeverOverrides_AndWorkerZones(t *testing.T) {
 	}
 	if lotScanValue2 != "required-if-lot-tracked" {
 		t.Errorf("post-Reset pick.lotScan = %q, want %q (override should still win)", lotScanValue2, "required-if-lot-tracked")
+	}
+
+	// Re-assert B6 new-lever override still wins post-Reset.
+	cycleCountSetting2, err := db.BusDomain.Settings.QueryByKey(ctx, "cycleCount.locationScan")
+	if err != nil {
+		t.Fatalf("query cycleCount.locationScan post-Reset: %v", err)
+	}
+	var cycleCountValue2 string
+	if err := json.Unmarshal(cycleCountSetting2.Value, &cycleCountValue2); err != nil {
+		t.Fatalf("unmarshal cycleCount.locationScan value post-Reset: %v", err)
+	}
+	if cycleCountValue2 != "button-confirm" {
+		t.Errorf("post-Reset cycleCount.locationScan = %q, want %q (override should still win)", cycleCountValue2, "button-confirm")
 	}
 
 	// Re-assert worker zones still applied post-Reset.


### PR DESCRIPTION
## Summary

Closes the seed gap that B5 (PR #133) left when F1.0 expanded the lever set from 11 to 17.

- Adds 6 keys to `levers.Defaults` + `KnownKeys` (camelCase, matching B5 row format and spec §3.3 notation).
- F1.B–E frontend consumers (`useCycleCount`, `useAdjustment`, `usePutAway`, `useInspection`) can now read the new keys via `GET /v1/config/settings`.
- `seedSettings()` iterates `levers.KnownKeys` dynamically (per B5-followup I1's `InsertPlatformConfig` wiring) — new rows flow through automatically; no seed-logic changes needed.

## New keys

| Key | SMB default | Owning composable |
|---|---|---|
| `adjustment.locationScan` | `required` | useAdjustment (F1.C) |
| `cycleCount.locationScan` | `required` | useCycleCount (F1.B) |
| `inspection.lotScan` | `disabled` | useInspection (F1.E) |
| `putaway.destinationLocationScan` | `required` | usePutAway (F1.D) |
| `putaway.itemScan` | `required` | usePutAway (F1.D) |
| `putaway.lotScan` | `disabled` | usePutAway (F1.D) |

All 6 are overridable. `nonOverridableKeys` remains `{pick.productScan}` per spec §3.3 invariant 1.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./business/domain/config/settingsbus/levers/...` — count assertion bumped 11→17, all 8 tests pass
- [x] `go test ./business/domain/scenarios/scenariobus/...` — new `cycleCount.locationScan` override assertion passes (Load + post-Reset)
- [x] `go test ./business/sdk/dbtest/...` — `seed_integration_test` dynamically iterates `levers.KnownKeys`, now seeds 17 rows
- [ ] After merge + `make reseed-frontend`: `SELECT key, value FROM config.settings WHERE key LIKE 'putaway.%' OR key LIKE 'cycleCount.%' OR key LIKE 'adjustment.%' OR key LIKE 'inspection.%' ORDER BY key` returns 6 new rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)