### PR TITLE
fix(inventory): restore notes validator to omitempty (regression revert)

### DIFF
--- a/api/cmd/services/ichor/tests/inventory/inventoryadjustmentapi/create_test.go
+++ b/api/cmd/services/ichor/tests/inventory/inventoryadjustmentapi/create_test.go
@@ -217,27 +217,6 @@ func create400(sd apitest.SeedData) []apitest.Table {
 			},
 		},
 		{
-			Name:       "missing-notes",
-			URL:        "/v1/inventory/inventory-adjustments",
-			Token:      sd.Admins[0].Token,
-			Method:     http.MethodPost,
-			StatusCode: http.StatusBadRequest,
-			Input: &inventoryadjustmentapp.NewInventoryAdjustment{
-				ProductID:      sd.Products[0].ProductID,
-				LocationID:     sd.InventoryLocations[0].LocationID,
-				AdjustedBy:     sd.InventoryAdjustments[0].AdjustedBy,
-				ApprovedBy:     sd.InventoryAdjustments[0].ApprovedBy,
-				QuantityChange: "10",
-				ReasonCode:     "damaged",
-				AdjustmentDate: now.Format(timeutil.FORMAT),
-			},
-			GotResp: &errs.Error{},
-			ExpResp: errs.Newf(errs.InvalidArgument, "validate: [{\"field\":\"notes\",\"error\":\"notes is a required field\"}]"),
-			CmpFunc: func(got, exp any) string {
-				return cmp.Diff(got, exp)
-			},
-		},
-		{
 			Name:       "missing-adjustment-date",
 			URL:        "/v1/inventory/inventory-adjustments",
 			Token:      sd.Admins[0].Token,

--- a/app/domain/inventory/inventoryadjustmentapp/model.go
+++ b/app/domain/inventory/inventoryadjustmentapp/model.go
@@ -109,7 +109,7 @@ type NewInventoryAdjustment struct {
 	ApprovedBy     string `json:"approved_by" validate:"required,min=36,max=36"`
 	QuantityChange string `json:"quantity_change" validate:"required"`
 	ReasonCode     string `json:"reason_code" validate:"required,oneof=damaged theft data_entry_error receiving_error picking_error found_stock other"`
-	Notes          string `json:"notes" validate:"required"`
+	Notes          string `json:"notes" validate:"omitempty"`
 	AdjustmentDate string `json:"adjustment_date" validate:"required"`
 }
 


### PR DESCRIPTION
## Summary

Reverts a one-line regression in `inventoryadjustmentapp.NewInventoryAdjustment.Notes` validator.

- `Notes` was silently changed from `validate:"omitempty"` to `validate:"required"` in commit `7bef17ed` (2026-03-16, "feat(inventory): validate adjustment reason codes at all layers"). The commit's stated scope was reason_code enum validation; the notes change appears to be unintentional drift.
- The frontend UI labels notes as "Optional" (placeholder: "Describe what happened (optional)...") and the supervisor approval workflow doesn't require notes either. The original `a1c51f0e` (2026-03-04, "notes optional") intent stands.
- `UpdateInventoryAdjustment.Notes` already has `omitempty` — this fix brings the create side in line.
- Drops the corresponding apitest case `missing-notes` since the validator no longer rejects empty notes.

## Why this surfaced now

Discovered via floor E2E adjustments happy-path test failing with `400 - validate: [{"field":"notes","error":"notes is a required field"}]`. The frontend correctly sends `notes: ""` when the user leaves the textarea blank; backend regression rejected it.

## Companion PR

phase-0g.E1 frontend PR ([timmaaaz/ichor-frontend](https://github.com/timmaaaz/ichor-frontend)) — same investigation surface; that PR also fixes a separate `approved_by` + `reason_code` cycle-count drift on the frontend.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./api/cmd/services/ichor/tests/inventory/inventoryadjustmentapi/...` green (`5.9s`)
- [ ] Floor E2E adjustments happy-path passes once frontend E1 PR rebases on this

## Out of scope (future work)

`approved_by` is currently `validate:"required"` on the create DTO, but the domain workflow has supervisor approval as a separate `approve_adjustment` workflow action — meaning approval shouldn't be set at create time for some operations. A future `*.approvalRequired` lever family (per phase 0g lever-system pattern) is the right place to make this customer-configurable (SMB self-approve vs enterprise supervisor-approve). The frontend currently sends `approved_by: <currentUser>` as an SMB-default workaround; this PR doesn't touch that.