### PR TITLE
phase-0g.E2 backend companion: add e2e-baseline + e2e-pick-strict scenarios

### DIFF
--- a/deployments/scenarios/e2e-baseline/scenario.yaml
+++ b/deployments/scenarios/e2e-baseline/scenario.yaml
@@ -1,0 +1,14 @@
+# deployments/scenarios/e2e-baseline/scenario.yaml
+#
+# Empty scenario reserved for E2E tests. No fixtures, no lever_overrides.
+# `leverOverrides.clearActiveScenario()` loads this to revert the running
+# system to SMB-default lever values between tests/specs that override them.
+#
+# UUID is omitted — yamlload computes UUID v5 of "scenario:e2e-baseline"
+# under the deadbeef-dead-beef-dead-beefdeadbeef namespace at parse time.
+# Byte-identical across reseeds per Phase 0d Decision 3.
+
+name: e2e-baseline
+description: |
+  Empty E2E baseline scenario. Loading this clears any active lever_overrides
+  by virtue of having none of its own. Used by leverOverrides.clearActiveScenario().

--- a/deployments/scenarios/e2e-baseline/scenario.yaml
+++ b/deployments/scenarios/e2e-baseline/scenario.yaml
@@ -4,7 +4,7 @@
 # `leverOverrides.clearActiveScenario()` loads this to revert the running
 # system to SMB-default lever values between tests/specs that override them.
 #
-# UUID is omitted — yamlload computes UUID v5 of "scenario:e2e-baseline"
+# ID is omitted — yamlload.loadOne computes UUID v5 of "scenario:e2e-baseline"
 # under the deadbeef-dead-beef-dead-beefdeadbeef namespace at parse time.
 # Byte-identical across reseeds per Phase 0d Decision 3.
 

--- a/deployments/scenarios/e2e-pick-strict/scenario.yaml
+++ b/deployments/scenarios/e2e-pick-strict/scenario.yaml
@@ -1,7 +1,7 @@
 # deployments/scenarios/e2e-pick-strict/scenario.yaml
 #
 # E2E lever-variant scenario for pick-strict.spec.ts. Flips pick.lotScan
-# from its SMB-default ("optional" — lot-scan step shown but skippable) to
+# from its SMB-default ("disabled" — lot-scan step not enforced) to
 # "required-if-lot-tracked" (lot-scan step enforced for lot-tracked products).
 # Used by the canonical lever-variant test pattern in pick-strict.spec.ts.
 

--- a/deployments/scenarios/e2e-pick-strict/scenario.yaml
+++ b/deployments/scenarios/e2e-pick-strict/scenario.yaml
@@ -1,0 +1,14 @@
+# deployments/scenarios/e2e-pick-strict/scenario.yaml
+#
+# E2E lever-variant scenario for pick-strict.spec.ts. Flips pick.lotScan
+# from its SMB-default ("optional" — lot-scan step shown but skippable) to
+# "required-if-lot-tracked" (lot-scan step enforced for lot-tracked products).
+# Used by the canonical lever-variant test pattern in pick-strict.spec.ts.
+
+name: e2e-pick-strict
+description: |
+  E2E lever-variant scenario. Pick flow runs in strict lot-scan mode.
+  Companion to pick.spec.ts (which runs against SMB defaults).
+
+lever_overrides:
+  pick.lotScan: required-if-lot-tracked


### PR DESCRIPTION
## Summary
Adds two new pre-seeded scenarios under `deployments/scenarios/` that the frontend Phase 0g.E2 PR depends on:

- `e2e-baseline/` — empty scenario; `leverOverrides.clearActiveScenario()` loads it to revert to SMB defaults between tests.
- `e2e-pick-strict/` — `pick.lotScan: required-if-lot-tracked`; powers the canonical lever-variant test pair (`pick.spec.ts` + `pick-strict.spec.ts`).

No fixtures on either; no behavior change for non-E2E callers.

## Test plan
- [x] `go test ./business/domain/scenarios/scenariobus/yamlload/...` — PASS
- [x] `go test ./business/sdk/dbtest/... -run TestSeed` — PASS
- [ ] Frontend Phase 0g.E2 PR (timmaaaz/ichor-frontend) merges first via this scenario presence

🤖 Generated with [Claude Code](https://claude.com/claude-code)