### PR TITLE
phase-0g.E2 backend follow-up: config.settings READ grant + _schema.yaml comment

### DIFF
--- a/business/sdk/migrate/sql/seed.sql
+++ b/business/sdk/migrate/sql/seed.sql
@@ -471,6 +471,7 @@ INSERT INTO core.table_access (id, role_id, table_name, can_create, can_read, ca
     (gen_random_uuid(), '54bb2165-71e1-41a6-af3e-7da4a0e1e2c1', 'assets.user_assets', true, true, true, true),
     (gen_random_uuid(), '54bb2165-71e1-41a6-af3e-7da4a0e1e2c1', 'assets.valid_assets', true, true, true, true),
     -- config schema
+    (gen_random_uuid(), '54bb2165-71e1-41a6-af3e-7da4a0e1e2c1', 'config.settings', true, true, true, true),
     (gen_random_uuid(), '54bb2165-71e1-41a6-af3e-7da4a0e1e2c1', 'config.form_fields', true, true, true, true),
     (gen_random_uuid(), '54bb2165-71e1-41a6-af3e-7da4a0e1e2c1', 'formdata', true, true, true, true),
     (gen_random_uuid(), '54bb2165-71e1-41a6-af3e-7da4a0e1e2c1', 'config.forms', true, true, true, true),
@@ -613,7 +614,9 @@ INSERT INTO core.table_access (id, role_id, table_name, can_create, can_read, ca
     (gen_random_uuid(), 'b0000000-0000-4000-8000-000000000001', 'inventory.warehouses', false, true, false, false),
     (gen_random_uuid(), 'b0000000-0000-4000-8000-000000000001', 'products.products', false, true, false, false),
     (gen_random_uuid(), 'b0000000-0000-4000-8000-000000000001', 'sales.order_line_items', false, true, false, false),
-    (gen_random_uuid(), 'b0000000-0000-4000-8000-000000000001', 'sales.orders', false, true, false, false)
+    (gen_random_uuid(), 'b0000000-0000-4000-8000-000000000001', 'sales.orders', false, true, false, false),
+    -- Config settings: read-only so the floor UI can load lever overrides (pick.lotScan etc.)
+    (gen_random_uuid(), 'b0000000-0000-4000-8000-000000000001', 'config.settings', false, true, false, false)
 ON CONFLICT DO NOTHING;
 
 -- Grant FLOOR_WORKER workflow action permissions for warehouse operations

--- a/business/sdk/migrate/sql/seed.sql
+++ b/business/sdk/migrate/sql/seed.sql
@@ -471,7 +471,6 @@ INSERT INTO core.table_access (id, role_id, table_name, can_create, can_read, ca
     (gen_random_uuid(), '54bb2165-71e1-41a6-af3e-7da4a0e1e2c1', 'assets.user_assets', true, true, true, true),
     (gen_random_uuid(), '54bb2165-71e1-41a6-af3e-7da4a0e1e2c1', 'assets.valid_assets', true, true, true, true),
     -- config schema
-    (gen_random_uuid(), '54bb2165-71e1-41a6-af3e-7da4a0e1e2c1', 'config.settings', true, true, true, true),
     (gen_random_uuid(), '54bb2165-71e1-41a6-af3e-7da4a0e1e2c1', 'config.form_fields', true, true, true, true),
     (gen_random_uuid(), '54bb2165-71e1-41a6-af3e-7da4a0e1e2c1', 'formdata', true, true, true, true),
     (gen_random_uuid(), '54bb2165-71e1-41a6-af3e-7da4a0e1e2c1', 'config.forms', true, true, true, true),
@@ -481,6 +480,7 @@ INSERT INTO core.table_access (id, role_id, table_name, can_create, can_read, ca
     (gen_random_uuid(), '54bb2165-71e1-41a6-af3e-7da4a0e1e2c1', 'config.page_actions', true, true, true, true),
     (gen_random_uuid(), '54bb2165-71e1-41a6-af3e-7da4a0e1e2c1', 'config.page_configs', true, true, true, true),
     (gen_random_uuid(), '54bb2165-71e1-41a6-af3e-7da4a0e1e2c1', 'config.page_content', true, true, true, true),
+    (gen_random_uuid(), '54bb2165-71e1-41a6-af3e-7da4a0e1e2c1', 'config.settings', true, true, true, true),
     (gen_random_uuid(), '54bb2165-71e1-41a6-af3e-7da4a0e1e2c1', 'config.table_configs', true, true, true, true),
     -- core schema
     (gen_random_uuid(), '54bb2165-71e1-41a6-af3e-7da4a0e1e2c1', 'core.contact_infos', true, true, true, true),

--- a/deployments/scenarios/_schema.yaml
+++ b/deployments/scenarios/_schema.yaml
@@ -19,10 +19,11 @@
 #               map[string]string, optional. Per-scenario overrides for
 #               scan-discipline lever keys. Keys must be in the canonical
 #               set (see business/domain/config/settingsbus/levers/levers.go
-#               for the 11 supported keys; design doc 2026-04-24 §3.3 for
-#               semantics). Values are free-form strings consumed by the
-#               settings resolver. Mirrored into config.scenario_setting_overrides
-#               at seed time; settings GET returns the merged view.
+#               for the supported keys and overridability rules; design doc
+#               2026-04-24 §3.3 for semantics). Values are free-form strings
+#               consumed by the settings resolver. Mirrored into
+#               config.scenario_setting_overrides at seed time; settings GET
+#               returns the merged view.
 #
 # bindings.yaml:
 #   totes     list of {code: string}


### PR DESCRIPTION
## Summary

Two small follow-ups uncovered while authoring `pick-strict.spec.ts` (frontend Phase 0g.E2 Task 14):

### 1. `seed.sql` — config.settings READ grant for ZZZADMIN + FLOOR_WORKER (`dc450903`)
Both roles were missing the `config.settings` READ grant. Result: every `loadConfig()` call from the floor flow silently returned 403, which masked four downstream frontend bugs in the lever-override pipeline. Without this grant the new `e2e-pick-strict` scenario (PR #140) cannot be observed by the frontend at all.

### 2. `_schema.yaml` — drop stale "11 supported keys" wording (`264b0ab9`)
The `lever_overrides` description block claimed the canonical key set has 11 entries — accurate at authoring time but stale since Phase 0g.B6 added 6 new scan-discipline levers. Replaced the hard count with a pointer to `levers.go` for "the supported keys and overridability rules", which avoids future count drift and exposes the `IsOverridable` distinction.

## Companion frontend PR

Frontend Phase 0g.E2 PR (timmaaaz/ichor-frontend) carries 4 production bug fixes in the lever-override pipeline that this grant unmasked:
- `useWorkflowConfig.ts` snake_case → camelCase keys (overrides were silently invisible)
- `PickConfig.lotScan` retyped to `LotCaptureMode`
- `usePicking.ts` race: await config before resolving order load
- `leverOverrides.ts` E2E fixture response-shape cast

This backend PR should land first so the frontend PR's pick-strict spec runs green in CI.

## Test plan

- [x] `go test ./business/sdk/migrate/...` (seed.sql grant validates)
- [x] Local `make dev-update-apply` reseeded; pick-strict.spec.ts passes 3/3 against this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)