### PR TITLE
fix(labels): resize location/tote ZPL to 4"×6" GK420t media

### DIFF
--- a/business/domain/labels/labelbus/zpl/location.go
+++ b/business/domain/labels/labelbus/zpl/location.go
@@ -5,14 +5,18 @@ import (
 	"strings"
 )
 
-// Location renders a 2"×1" @ 203 DPI ZPL location label:
-// human-readable code + Code128 barcode of the same code.
-// Matches the Phase 0 smoke pattern (NOTES.md 2026-04-14).
+// Location renders a 4"×6" @ 203 DPI ZPL location label:
+// large human-readable code + Code128 barcode of the same code.
+// Sized for Zebra GK420t with 4×6 thermal-transfer media.
+//
+// Layout (203 DPI: 1" = 203 dots; label is 812w × 1218h):
+//   Code text (150-dot font) — top
+//   Code128 barcode (BY4, 250-dot height, with human-readable) — middle
 func Location(d LocationData) string {
 	var b strings.Builder
 	b.WriteString("^XA\n")
-	b.WriteString(fmt.Sprintf("^FO50,50^A0N,40,40^FD%s^FS\n", d.Code))
-	b.WriteString(fmt.Sprintf("^FO50,100^BY2^BCN,80,Y,N,N^FD%s^FS\n", d.Code))
+	b.WriteString(fmt.Sprintf("^FO40,80^A0N,150,150^FD%s^FS\n", d.Code))
+	b.WriteString(fmt.Sprintf("^FO40,300^BY4^BCN,250,Y,N,N^FD%s^FS\n", d.Code))
 	b.WriteString("^XZ\n")
 	return b.String()
 }

--- a/business/domain/labels/labelbus/zpl/tote.go
+++ b/business/domain/labels/labelbus/zpl/tote.go
@@ -5,15 +5,15 @@ import (
 	"strings"
 )
 
-// Tote renders a 2"×1" @ 203 DPI ZPL tote label.
+// Tote renders a 4"×6" @ 203 DPI ZPL tote label.
 // Shares layout with Location at Phase 0b; diverges in Phase 1+ when
 // totes gain lot-expiry/icon fields. Kept as a separate function so
 // call sites read intention rather than implementation.
 func Tote(d ToteData) string {
 	var b strings.Builder
 	b.WriteString("^XA\n")
-	b.WriteString(fmt.Sprintf("^FO50,50^A0N,40,40^FD%s^FS\n", d.Code))
-	b.WriteString(fmt.Sprintf("^FO50,100^BY2^BCN,80,Y,N,N^FD%s^FS\n", d.Code))
+	b.WriteString(fmt.Sprintf("^FO40,80^A0N,150,150^FD%s^FS\n", d.Code))
+	b.WriteString(fmt.Sprintf("^FO40,300^BY4^BCN,250,Y,N,N^FD%s^FS\n", d.Code))
 	b.WriteString("^XZ\n")
 	return b.String()
 }

--- a/business/domain/labels/labelbus/zpl/zpl_test.go
+++ b/business/domain/labels/labelbus/zpl/zpl_test.go
@@ -11,8 +11,8 @@ func strPtr(s string) *string { return &s }
 func Test_Location_Snapshot(t *testing.T) {
 	got := zpl.Location(zpl.LocationData{Code: "STG-A02"})
 	want := "^XA\n" +
-		"^FO50,50^A0N,40,40^FDSTG-A02^FS\n" +
-		"^FO50,100^BY2^BCN,80,Y,N,N^FDSTG-A02^FS\n" +
+		"^FO40,80^A0N,150,150^FDSTG-A02^FS\n" +
+		"^FO40,300^BY4^BCN,250,Y,N,N^FDSTG-A02^FS\n" +
 		"^XZ\n"
 	if got != want {
 		t.Fatalf("location snapshot drift.\nwant:\n%q\ngot:\n%q\n", want, got)
@@ -22,8 +22,8 @@ func Test_Location_Snapshot(t *testing.T) {
 func Test_Tote_Snapshot(t *testing.T) {
 	got := zpl.Tote(zpl.ToteData{Code: "TOTE-007"})
 	want := "^XA\n" +
-		"^FO50,50^A0N,40,40^FDTOTE-007^FS\n" +
-		"^FO50,100^BY2^BCN,80,Y,N,N^FDTOTE-007^FS\n" +
+		"^FO40,80^A0N,150,150^FDTOTE-007^FS\n" +
+		"^FO40,300^BY4^BCN,250,Y,N,N^FDTOTE-007^FS\n" +
 		"^XZ\n"
 	if got != want {
 		t.Fatalf("tote snapshot drift.\nwant:\n%q\ngot:\n%q\n", want, got)


### PR DESCRIPTION
## Summary

- `location.go` and `tote.go` were authored at 2"×1" during Phase 0b but the established Zebra GK420t media stock is 4"×6" — Phase 0-print physical testing revealed the labels rendering in the upper-left corner of the actual stock.
- Resized both templates to mirror `product.go`'s 812×1218 @ 203 DPI layout (150-dot code text on top, BY4/250-dot Code128 barcode with human-readable subtitle below). Body is byte-identical between Location and Tote per Phase 0b's "identical body" intent.
- Snapshot tests in `zpl_test.go` regenerated; product snapshots unchanged; no other Go file referenced the old 2×1 coordinates.

## Notes

- Frontend arch doc (`docs/arch/labels.md` lines 43–44) lives in the frontend repo — separate follow-up.
- No `^PW` / `^LL` emitted, matching `product.go`'s convention of relying on printer media config.

## Test plan

- [x] `go build ./business/domain/labels/...`
- [x] `go test ./business/domain/labels/labelbus/...` (zpl, labelbus, labeldb store, tcpprint all pass)
- [x] `grep` for old `FO50,50` / `FO50,100` coordinates across all Go — zero hits
- [ ] `make dev-bounce` then physical print smoke on the GK420t (label fills 4×6 media; readable from working distance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)