### PR TITLE
phase-1: re-seed inventory_locations to 19 spec §3.4 codes

### DIFF
--- a/api/cmd/services/ichor/tests/data/seed_test.go
+++ b/api/cmd/services/ichor/tests/data/seed_test.go
@@ -870,7 +870,7 @@ func insertSeedData(db *dbtest.Database, ath *auth.Auth) (apitest.SeedData, erro
 		return apitest.SeedData{}, fmt.Errorf("seeding zones : %w", err)
 	}
 
-	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 25, warehouseIDs, zones, busDomain.InventoryLocation)
+	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 19, warehouseIDs, zones, busDomain.InventoryLocation)
 	if err != nil {
 		return apitest.SeedData{}, fmt.Errorf("seeding inventory locations : %w", err)
 	}

--- a/api/cmd/services/ichor/tests/formdata/formdataapi/seed_test.go
+++ b/api/cmd/services/ichor/tests/formdata/formdataapi/seed_test.go
@@ -176,7 +176,7 @@ func insertSeedData(db *dbtest.Database, ath *auth.Auth) (apitest.SeedData, erro
 		return apitest.SeedData{}, fmt.Errorf("seeding zones : %w", err)
 	}
 
-	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 25, warehouseIDs, zones, busDomain.InventoryLocation)
+	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 19, warehouseIDs, zones, busDomain.InventoryLocation)
 	if err != nil {
 		return apitest.SeedData{}, fmt.Errorf("seeding inventory locations : %w", err)
 	}

--- a/api/cmd/services/ichor/tests/inventory/inventoryadjustmentapi/seed_test.go
+++ b/api/cmd/services/ichor/tests/inventory/inventoryadjustmentapi/seed_test.go
@@ -106,7 +106,7 @@ func insertSeedData(db *dbtest.Database, ath *auth.Auth) (apitest.SeedData, erro
 		return apitest.SeedData{}, fmt.Errorf("seeding zones : %w", err)
 	}
 
-	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 25, warehouseIDs, zones, busDomain.InventoryLocation)
+	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 19, warehouseIDs, zones, busDomain.InventoryLocation)
 	if err != nil {
 		return apitest.SeedData{}, fmt.Errorf("seeding inventory locations : %w", err)
 	}

--- a/api/cmd/services/ichor/tests/inventory/inventoryitemapi/create_test.go
+++ b/api/cmd/services/ichor/tests/inventory/inventoryitemapi/create_test.go
@@ -19,9 +19,13 @@ func create200(sd apitest.SeedData) []apitest.Table {
 			Token:      sd.Admins[0].Token,
 			Method:     http.MethodPost,
 			StatusCode: http.StatusOK,
+			// Post-Phase-1 the seed uses 19 locations and creates 50 items
+			// over a (location, product) grid. (loc[0], prod[2]) is now
+			// occupied by seed item i=38 — pick the free pair (loc[18],
+			// prod[2]) for the 200 create case so it does not collide.
 			Input: &inventoryitemapp.NewInventoryItem{
 				ProductID:             sd.Products[2].ProductID,
-				LocationID:            sd.InventoryLocations[0].LocationID,
+				LocationID:            sd.InventoryLocations[18].LocationID,
 				Quantity:              "10",
 				ReservedQuantity:      "50",
 				AllocatedQuantity:     "100",
@@ -35,7 +39,7 @@ func create200(sd apitest.SeedData) []apitest.Table {
 			GotResp: &inventoryitemapp.InventoryItem{},
 			ExpResp: &inventoryitemapp.InventoryItem{
 				ProductID:             sd.Products[2].ProductID,
-				LocationID:            sd.InventoryLocations[0].LocationID,
+				LocationID:            sd.InventoryLocations[18].LocationID,
 				Quantity:              "10",
 				ReservedQuantity:      "50",
 				AllocatedQuantity:     "100",

--- a/api/cmd/services/ichor/tests/inventory/inventoryitemapi/seed_test.go
+++ b/api/cmd/services/ichor/tests/inventory/inventoryitemapi/seed_test.go
@@ -156,7 +156,7 @@ func insertSeedData(db *dbtest.Database, ath *auth.Auth) (apitest.SeedData, erro
 		return apitest.SeedData{}, fmt.Errorf("seeding zones : %w", err)
 	}
 
-	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 25, warehouseIDs, zones, busDomain.InventoryLocation)
+	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 19, warehouseIDs, zones, busDomain.InventoryLocation)
 	if err != nil {
 		return apitest.SeedData{}, fmt.Errorf("seeding inventory locations : %w", err)
 	}

--- a/api/cmd/services/ichor/tests/inventory/inventorylocationapi/query_test.go
+++ b/api/cmd/services/ichor/tests/inventory/inventorylocationapi/query_test.go
@@ -20,7 +20,7 @@ func query200(sd apitest.SeedData) []apitest.Table {
 			ExpResp: &query.Result[inventorylocationapp.InventoryLocation]{
 				Page:        1,
 				RowsPerPage: 10,
-				Total:       25,
+				Total:       19,
 				Items:       sd.InventoryLocations[:10],
 			},
 			CmpFunc: func(got, exp any) string {

--- a/api/cmd/services/ichor/tests/inventory/inventorylocationapi/seed_test.go
+++ b/api/cmd/services/ichor/tests/inventory/inventorylocationapi/seed_test.go
@@ -98,7 +98,7 @@ func insertSeedData(db *dbtest.Database, ath *auth.Auth) (apitest.SeedData, erro
 		return apitest.SeedData{}, fmt.Errorf("seeding zones : %w", err)
 	}
 
-	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 25, warehouseIDs, zones, busDomain.InventoryLocation)
+	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 19, warehouseIDs, zones, busDomain.InventoryLocation)
 	if err != nil {
 		return apitest.SeedData{}, fmt.Errorf("seeding inventory locations : %w", err)
 	}

--- a/api/cmd/services/ichor/tests/inventory/inventorytransactionapi/seed_test.go
+++ b/api/cmd/services/ichor/tests/inventory/inventorytransactionapi/seed_test.go
@@ -106,7 +106,7 @@ func insertSeedData(db *dbtest.Database, ath *auth.Auth) (apitest.SeedData, erro
 		return apitest.SeedData{}, fmt.Errorf("seeding zones : %w", err)
 	}
 
-	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 25, warehouseIDs, zones, busDomain.InventoryLocation)
+	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 19, warehouseIDs, zones, busDomain.InventoryLocation)
 	if err != nil {
 		return apitest.SeedData{}, fmt.Errorf("seeding inventory locations : %w", err)
 	}

--- a/api/cmd/services/ichor/tests/inventory/scanapi/seed_test.go
+++ b/api/cmd/services/ichor/tests/inventory/scanapi/seed_test.go
@@ -158,7 +158,7 @@ func insertSeedData(db *dbtest.Database, ath *auth.Auth) (apitest.SeedData, erro
 		return apitest.SeedData{}, fmt.Errorf("seeding zones : %w", err)
 	}
 
-	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 25, warehouseIDs, zones, busDomain.InventoryLocation)
+	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 19, warehouseIDs, zones, busDomain.InventoryLocation)
 	if err != nil {
 		return apitest.SeedData{}, fmt.Errorf("seeding inventory locations : %w", err)
 	}

--- a/api/cmd/services/ichor/tests/inventory/serialnumberapi/seed_test.go
+++ b/api/cmd/services/ichor/tests/inventory/serialnumberapi/seed_test.go
@@ -157,7 +157,7 @@ func insertSeedData(db *dbtest.Database, ath *auth.Auth) (apitest.SeedData, erro
 		return apitest.SeedData{}, fmt.Errorf("seeding zones : %w", err)
 	}
 
-	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 25, warehouseIDs, zones, busDomain.InventoryLocation)
+	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 19, warehouseIDs, zones, busDomain.InventoryLocation)
 	if err != nil {
 		return apitest.SeedData{}, fmt.Errorf("seeding inventory locations : %w", err)
 	}

--- a/api/cmd/services/ichor/tests/inventory/transferorderapi/seed_test.go
+++ b/api/cmd/services/ichor/tests/inventory/transferorderapi/seed_test.go
@@ -126,7 +126,7 @@ func insertSeedData(db *dbtest.Database, ath *auth.Auth) (apitest.SeedData, erro
 		return apitest.SeedData{}, fmt.Errorf("seeding zones : %w", err)
 	}
 
-	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 25, warehouseIDs, zones, busDomain.InventoryLocation)
+	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 19, warehouseIDs, zones, busDomain.InventoryLocation)
 	if err != nil {
 		return apitest.SeedData{}, fmt.Errorf("seeding inventory locations : %w", err)
 	}

--- a/business/domain/inventory/inventoryadjustmentbus/inventoryadjustmentbus_test.go
+++ b/business/domain/inventory/inventoryadjustmentbus/inventoryadjustmentbus_test.go
@@ -154,7 +154,7 @@ func insertSeedData(busDomain dbtest.BusDomain) (unitest.SeedData, error) {
 		return unitest.SeedData{}, fmt.Errorf("seeding zones : %w", err)
 	}
 
-	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 25, warehouseIDs, zones, busDomain.InventoryLocation)
+	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 19, warehouseIDs, zones, busDomain.InventoryLocation)
 	if err != nil {
 		return unitest.SeedData{}, fmt.Errorf("seeding inventory locations : %w", err)
 	}

--- a/business/domain/inventory/inventoryitembus/inventoryitembus_test.go
+++ b/business/domain/inventory/inventoryitembus/inventoryitembus_test.go
@@ -163,7 +163,7 @@ func insertSeedData(busDomain dbtest.BusDomain) (unitest.SeedData, error) {
 		return unitest.SeedData{}, fmt.Errorf("seeding zones : %w", err)
 	}
 
-	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 25, warehouseIDs, zones, busDomain.InventoryLocation)
+	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 19, warehouseIDs, zones, busDomain.InventoryLocation)
 	if err != nil {
 		return unitest.SeedData{}, fmt.Errorf("seeding inventory locations : %w", err)
 	}
@@ -187,14 +187,21 @@ func insertSeedData(busDomain dbtest.BusDomain) (unitest.SeedData, error) {
 }
 
 func query(busDomain dbtest.BusDomain, sd unitest.SeedData) []unitest.Table {
-	// Filter to items belonging to Products[1] (grid positions 25-29, exactly 5 items).
-	// Using a ProductID filter scopes the query to test-specific rows and avoids
-	// contamination from the global seed's inventory items.
+	// Filter to items belonging to Products[1]. Post-Phase-1 the grid is
+	// 30 items × 19 locations × 20 products: items 19-29 (11 items) carry
+	// Products[1]. The query below pages 5, so we cap expItems to the first
+	// 5 (DefaultOrderBy = id ASC; seed is pre-sorted by id, so positional
+	// order of expItems and got match).
+	// Using a ProductID filter scopes the query to test-specific rows and
+	// avoids contamination from the global seed's inventory items.
 	p1ID := sd.Products[1].ProductID
 	expItems := make([]inventoryitembus.InventoryItem, 0, 5)
 	for _, item := range sd.InventoryItems {
 		if item.ProductID == p1ID {
 			expItems = append(expItems, item)
+			if len(expItems) == 5 {
+				break
+			}
 		}
 	}
 
@@ -229,7 +236,7 @@ func create(busDomain dbtest.BusDomain, sd unitest.SeedData) []unitest.Table {
 		{
 			Name: "Create",
 			ExpResp: inventoryitembus.InventoryItem{
-				LocationID:            sd.InventoryLocations[5].LocationID,
+				LocationID:            sd.InventoryLocations[15].LocationID,
 				ProductID:             sd.Products[1].ProductID,
 				Quantity:              10,
 				ReservedQuantity:      15,
@@ -243,7 +250,7 @@ func create(busDomain dbtest.BusDomain, sd unitest.SeedData) []unitest.Table {
 			},
 			ExcFunc: func(ctx context.Context) any {
 				got, err := busDomain.InventoryItem.Create(ctx, inventoryitembus.NewInventoryItem{
-					LocationID:            sd.InventoryLocations[5].LocationID,
+					LocationID:            sd.InventoryLocations[15].LocationID,
 					ProductID:             sd.Products[1].ProductID,
 					Quantity:              10,
 					ReservedQuantity:      15,
@@ -283,7 +290,7 @@ func update(busDomain dbtest.BusDomain, sd unitest.SeedData) []unitest.Table {
 			Name: "Update",
 			ExpResp: inventoryitembus.InventoryItem{
 				ID:                    sd.InventoryItems[0].ID,
-				LocationID:            sd.InventoryLocations[6].LocationID,
+				LocationID:            sd.InventoryLocations[18].LocationID,
 				ProductID:             sd.Products[1].ProductID,
 				Quantity:              20,
 				ReservedQuantity:      25,
@@ -298,7 +305,7 @@ func update(busDomain dbtest.BusDomain, sd unitest.SeedData) []unitest.Table {
 			},
 			ExcFunc: func(ctx context.Context) any {
 				got, err := busDomain.InventoryItem.Update(ctx, sd.InventoryItems[0], inventoryitembus.UpdateInventoryItem{
-					LocationID:            &sd.InventoryLocations[6].LocationID,
+					LocationID:            &sd.InventoryLocations[18].LocationID,
 					ProductID:             &sd.Products[1].ProductID,
 					Quantity:              dbtest.IntPointer(20),
 					ReservedQuantity:      dbtest.IntPointer(25),
@@ -485,12 +492,15 @@ func Test_QueryAvailableForAllocation(t *testing.T) {
 		t.Fatalf("seeding warehouses: %s", err)
 	}
 
-	zones, err := zonebus.TestSeedZone(ctx, 1, uuid.UUIDs{warehouses[0].ID}, bd.Zones)
+	// Seed 3 zones (RCV/QA/STG per zoneCodeCycle) so the spec catalogue has
+	// at least 3 location codes available — this test needs 3 distinct
+	// locations for the FEFO/FIFO/LIFO ordering checks below.
+	zones, err := zonebus.TestSeedZone(ctx, 3, uuid.UUIDs{warehouses[0].ID}, bd.Zones)
 	if err != nil {
 		t.Fatalf("seeding zones: %s", err)
 	}
 
-	locations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 3, uuid.UUIDs{warehouses[0].ID}, []zonebus.Zone{zones[0]}, bd.InventoryLocation)
+	locations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 3, uuid.UUIDs{warehouses[0].ID}, zones, bd.InventoryLocation)
 	if err != nil {
 		t.Fatalf("seeding locations: %s", err)
 	}

--- a/business/domain/inventory/inventoryitembus/inventoryitembus_test.go
+++ b/business/domain/inventory/inventoryitembus/inventoryitembus_test.go
@@ -504,6 +504,9 @@ func Test_QueryAvailableForAllocation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("seeding locations: %s", err)
 	}
+	if len(locations) != 3 {
+		t.Fatalf("expected 3 seeded locations, got %d (zone codes may not match specCodes catalogue)", len(locations))
+	}
 	locIDs := make([]uuid.UUID, len(locations))
 	for i, l := range locations {
 		locIDs[i] = l.LocationID

--- a/business/domain/inventory/inventorylocationbus/inventorylocationbus_test.go
+++ b/business/domain/inventory/inventorylocationbus/inventorylocationbus_test.go
@@ -99,7 +99,7 @@ func insertSeedData(busDomain dbtest.BusDomain) (unitest.SeedData, error) {
 		return unitest.SeedData{}, fmt.Errorf("seeding zones : %w", err)
 	}
 
-	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 25, warehouseIDs, zones, busDomain.InventoryLocation)
+	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 19, warehouseIDs, zones, busDomain.InventoryLocation)
 	if err != nil {
 		return unitest.SeedData{}, fmt.Errorf("seeding inventory locations : %w", err)
 	}

--- a/business/domain/inventory/inventorylocationbus/testutil.go
+++ b/business/domain/inventory/inventorylocationbus/testutil.go
@@ -94,7 +94,7 @@ func TestNewInventoryLocation(n int, warehouseIDs []uuid.UUID, zones []zonebus.Z
 	}
 
 	out := make([]NewInventoryLocation, 0, n)
-	for i, sc := range specCodes {
+	for _, sc := range specCodes {
 		if len(out) >= n {
 			break
 		}
@@ -103,9 +103,9 @@ func TestNewInventoryLocation(n int, warehouseIDs []uuid.UUID, zones []zonebus.Z
 			continue
 		}
 		code := sc.code
-		// Alternate IsPickLocation/IsReserveLocation by spec-catalogue index
-		// (preserves the prior testutil behavior of producing both kinds).
-		isPick := i%2 == 0
+		// Alternate IsPickLocation/IsReserveLocation by emission position
+		// (so callers seeing partial-zone subsets still get both kinds).
+		isPick := len(out)%2 == 0
 		out = append(out, NewInventoryLocation{
 			WarehouseID:        warehouseIDs[0],
 			ZoneID:             zone.ZoneID,

--- a/business/domain/inventory/inventorylocationbus/testutil.go
+++ b/business/domain/inventory/inventorylocationbus/testutil.go
@@ -3,7 +3,6 @@ package inventorylocationbus
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"sort"
 
 	"github.com/google/uuid"
@@ -11,53 +10,131 @@ import (
 	"github.com/timmaaaz/ichor/business/domain/inventory/zonebus"
 )
 
-func TestNewInventoryLocation(n int, warehouseIDs []uuid.UUID, zones []zonebus.Zone) []NewInventoryLocation {
-	newInventoryLocations := make([]NewInventoryLocation, n)
+// specCode describes one of the 19 hardcoded warehouse locations from
+// Phase 1 spec §3.4 (physical warehouse layout). Each code corresponds to a
+// physical sticker on the warehouse floor that the floor app resolves via
+// LocationCodeExact lookup. See seed_scenarios_refs.go for the scan-key map.
+type specCode struct {
+	code    string // e.g. "STG-A01"
+	zonePfx string // owning zone's ZoneCode (RCV/QA/STG/PCK/PKG/SHP)
+	aisle   string // "A"/"B"/"C" for STG, "" for non-aisled zones
+	rack    string // 2-digit zero-padded numeric segment
+}
 
-	aisles := []string{"A", "B", "C"}
+// specCodes is the canonical, alphabetically-sorted catalogue of the 19
+// physical location codes. Order is fixed so callers indexing the returned
+// slice (e.g. sd.InventoryLocations[0]) get deterministic results across runs.
+var specCodes = []specCode{
+	{code: "PCK-01", zonePfx: "PCK", aisle: "", rack: "01"},
+	{code: "PCK-02", zonePfx: "PCK", aisle: "", rack: "02"},
+	{code: "PCK-03", zonePfx: "PCK", aisle: "", rack: "03"},
+	{code: "PKG-01", zonePfx: "PKG", aisle: "", rack: "01"},
+	{code: "PKG-02", zonePfx: "PKG", aisle: "", rack: "02"},
+	{code: "QA-01", zonePfx: "QA", aisle: "", rack: "01"},
+	{code: "RCV-01", zonePfx: "RCV", aisle: "", rack: "01"},
+	{code: "RCV-02", zonePfx: "RCV", aisle: "", rack: "02"},
+	{code: "SHP-01", zonePfx: "SHP", aisle: "", rack: "01"},
+	{code: "SHP-02", zonePfx: "SHP", aisle: "", rack: "02"},
+	{code: "STG-A01", zonePfx: "STG", aisle: "A", rack: "01"},
+	{code: "STG-A02", zonePfx: "STG", aisle: "A", rack: "02"},
+	{code: "STG-A03", zonePfx: "STG", aisle: "A", rack: "03"},
+	{code: "STG-B01", zonePfx: "STG", aisle: "B", rack: "01"},
+	{code: "STG-B02", zonePfx: "STG", aisle: "B", rack: "02"},
+	{code: "STG-B03", zonePfx: "STG", aisle: "B", rack: "03"},
+	{code: "STG-C01", zonePfx: "STG", aisle: "C", rack: "01"},
+	{code: "STG-C02", zonePfx: "STG", aisle: "C", rack: "02"},
+	{code: "STG-C03", zonePfx: "STG", aisle: "C", rack: "03"},
+}
 
-	idx := rand.Intn(10000)
-	for i := 0; i < n; i++ {
-		idx++
+// specCatalogueSize is the number of codes in specCodes. Exposed via the
+// returned error from TestNewInventoryLocation when n > catalogue size so
+// stale callers (passing the legacy n=25) fail loudly instead of silently
+// truncating.
+const specCatalogueSize = 19
 
-		// Warehouse-realistic codes: {ZoneCode}-{Aisle}{Rack}{Shelf}{Bin} format (spec §3.7, user-approved 2026-04-16).
-		// Aisles A/B/C, racks 01-05, shelves 01-04, bins 01-06.
-		// Zone prefix comes from the owning zone's ZoneCode (populated by TestNewZone in phase 0c.1).
-		aisle := aisles[idx%3]
-		rack := fmt.Sprintf("%02d", (idx/3)%5+1)
-		shelf := fmt.Sprintf("%02d", (idx/15)%4+1)
-		bin := fmt.Sprintf("%02d", (idx/60)%6+1)
+// TestNewInventoryLocation produces up to n NewInventoryLocation values
+// drawn from the Phase 1 spec §3.4 catalogue (specCodes). The function
+// matches each spec code against the first input zone whose ZoneCode equals
+// the code's zone prefix; codes whose prefix is absent from zones[] are
+// skipped, so the returned slice may be shorter than n.
+//
+// Aisle/Shelf/Bin: STG codes carry a real Aisle ("A"/"B"/"C") and Rack;
+// non-aisled zones (RCV/QA/PCK/PKG/SHP) use Aisle="" and only Rack.
+// Shelf and Bin are always "" — the spec catalogue does not currently
+// distinguish bin-level positions for these locations. The
+// inventory_locations schema (migrate.sql v1.52) declares aisle/rack/shelf/bin
+// as VARCHAR(20) NOT NULL with no CHECK constraint; empty strings are
+// schema-valid.
+//
+// Returns an error if n > specCatalogueSize (19) — this catches callers
+// still passing the legacy n=25 after the spec re-seed. Pass n=19 (or fewer
+// if the test only needs a subset).
+func TestNewInventoryLocation(n int, warehouseIDs []uuid.UUID, zones []zonebus.Zone) ([]NewInventoryLocation, error) {
+	if n > specCatalogueSize {
+		return nil, fmt.Errorf("n exceeds spec catalogue size (%d)", specCatalogueSize)
+	}
+	if n < 0 {
+		return nil, fmt.Errorf("n must be non-negative, got %d", n)
+	}
+	if len(warehouseIDs) == 0 {
+		return nil, fmt.Errorf("warehouseIDs must contain at least one warehouse")
+	}
 
-		zone := zones[idx%len(zones)]
-		zoneCode := ""
-		if zone.ZoneCode != nil {
-			zoneCode = *zone.ZoneCode
+	// Index zones by ZoneCode for first-match lookup.
+	zoneByCode := make(map[string]zonebus.Zone, len(zones))
+	for _, z := range zones {
+		if z.ZoneCode == nil {
+			continue
 		}
-		locationCode := fmt.Sprintf("%s-%s%s%s%s", zoneCode, aisle, rack, shelf, bin)
-
-		// Alternate: even indices are pick locations, odd are reserve
-		isPickLocation := i%2 == 0
-
-		newInventoryLocations[i] = NewInventoryLocation{
-			WarehouseID:        warehouseIDs[idx%len(warehouseIDs)],
-			ZoneID:             zone.ZoneID,
-			Aisle:              aisle,
-			Rack:               rack,
-			Shelf:              shelf,
-			Bin:                bin,
-			LocationCode:       &locationCode,
-			IsPickLocation:     isPickLocation,
-			IsReserveLocation:  !isPickLocation,
-			MaxCapacity:        idx%100 + 10,
-			CurrentUtilization: types.RoundedFloat{Value: float64(idx % 100)},
+		// Preserve first-occurrence semantics: if multiple zones share a
+		// code (zoneCodeCycle re-uses STG/PCK/PKG/RCV), only the first wins.
+		if _, ok := zoneByCode[*z.ZoneCode]; !ok {
+			zoneByCode[*z.ZoneCode] = z
 		}
 	}
 
-	return newInventoryLocations
+	out := make([]NewInventoryLocation, 0, n)
+	for i, sc := range specCodes {
+		if len(out) >= n {
+			break
+		}
+		zone, ok := zoneByCode[sc.zonePfx]
+		if !ok {
+			continue
+		}
+		code := sc.code
+		// Alternate IsPickLocation/IsReserveLocation by spec-catalogue index
+		// (preserves the prior testutil behavior of producing both kinds).
+		isPick := i%2 == 0
+		out = append(out, NewInventoryLocation{
+			WarehouseID:        warehouseIDs[0],
+			ZoneID:             zone.ZoneID,
+			Aisle:              sc.aisle,
+			Rack:               sc.rack,
+			Shelf:              "",
+			Bin:                "",
+			LocationCode:       &code,
+			IsPickLocation:     isPick,
+			IsReserveLocation:  !isPick,
+			MaxCapacity:        100,
+			CurrentUtilization: types.RoundedFloat{Value: 0},
+		})
+	}
+
+	return out, nil
 }
 
+// TestSeedInventoryLocations creates up to n inventory locations from the
+// Phase 1 spec §3.4 catalogue. See TestNewInventoryLocation for the
+// availability/zone-matching rules. The returned slice is sorted by
+// LocationID.String() for parity with the bus Query default order
+// (ORDER BY id ASC) — paged-query tests can compare positional indices
+// directly against this slice.
 func TestSeedInventoryLocations(ctx context.Context, n int, warehouseIDs []uuid.UUID, zones []zonebus.Zone, api *Business) ([]InventoryLocation, error) {
-	newInventoryLocations := TestNewInventoryLocation(n, warehouseIDs, zones)
+	newInventoryLocations, err := TestNewInventoryLocation(n, warehouseIDs, zones)
+	if err != nil {
+		return nil, err
+	}
 
 	inventoryLocations := make([]InventoryLocation, len(newInventoryLocations))
 

--- a/business/domain/inventory/inventorytransactionbus/inventorytransactionbus_test.go
+++ b/business/domain/inventory/inventorytransactionbus/inventorytransactionbus_test.go
@@ -154,7 +154,7 @@ func insertSeedData(busDomain dbtest.BusDomain) (unitest.SeedData, error) {
 		return unitest.SeedData{}, fmt.Errorf("seeding zones : %w", err)
 	}
 
-	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 25, warehouseIDs, zones, busDomain.InventoryLocation)
+	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 19, warehouseIDs, zones, busDomain.InventoryLocation)
 	if err != nil {
 		return unitest.SeedData{}, fmt.Errorf("seeding inventory locations : %w", err)
 	}

--- a/business/domain/inventory/serialnumberbus/serialnumberbus_test.go
+++ b/business/domain/inventory/serialnumberbus/serialnumberbus_test.go
@@ -187,7 +187,7 @@ func insertSeedData(busDomain dbtest.BusDomain) (unitest.SeedData, error) {
 		return unitest.SeedData{}, fmt.Errorf("seeding zones : %w", err)
 	}
 
-	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 25, warehouseIDs, zones, busDomain.InventoryLocation)
+	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 19, warehouseIDs, zones, busDomain.InventoryLocation)
 	if err != nil {
 		return unitest.SeedData{}, fmt.Errorf("seeding inventory locations : %w", err)
 	}

--- a/business/domain/inventory/transferorderbus/transferorderbus_test.go
+++ b/business/domain/inventory/transferorderbus/transferorderbus_test.go
@@ -174,7 +174,7 @@ func insertSeedData(busDomain dbtest.BusDomain) (unitest.SeedData, error) {
 		return unitest.SeedData{}, fmt.Errorf("seeding zones : %w", err)
 	}
 
-	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 25, warehouseIDs, zones, busDomain.InventoryLocation)
+	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 19, warehouseIDs, zones, busDomain.InventoryLocation)
 	if err != nil {
 		return unitest.SeedData{}, fmt.Errorf("seeding inventory locations : %w", err)
 	}

--- a/business/sdk/dbtest/seed_inventory.go
+++ b/business/sdk/dbtest/seed_inventory.go
@@ -64,7 +64,7 @@ func seedInventory(ctx context.Context, busDomain BusDomain, foundation Foundati
 		return InventorySeed{}, fmt.Errorf("seeding zones : %w", err)
 	}
 
-	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 25, warehouseIDs, zones, busDomain.InventoryLocation)
+	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 19, warehouseIDs, zones, busDomain.InventoryLocation)
 	if err != nil {
 		return InventorySeed{}, fmt.Errorf("seeding inventory locations : %w", err)
 	}

--- a/business/sdk/tablebuilder/tablebuilder_test.go
+++ b/business/sdk/tablebuilder/tablebuilder_test.go
@@ -1139,7 +1139,7 @@ func insertSeedData(busDomain dbtest.BusDomain, configStore *tablebuilder.Config
 		return unitest.SeedData{}, fmt.Errorf("seeding zones : %w", err)
 	}
 
-	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 25, warehouseIDs, zones, busDomain.InventoryLocation)
+	inventoryLocations, err := inventorylocationbus.TestSeedInventoryLocations(ctx, 19, warehouseIDs, zones, busDomain.InventoryLocation)
 	if err != nil {
 		return unitest.SeedData{}, fmt.Errorf("seeding inventory locations : %w", err)
 	}

--- a/docs/arch/seeding.md
+++ b/docs/arch/seeding.md
@@ -30,7 +30,7 @@ All values are randomized (names, IDs, dates). Only counts and relationships are
 | Label catalog | 79 | 19 location + 20 container + 40 product (one per seeded product) |
 | Warehouses | 5 | historical, 365-day window |
 | Zones | 12 | |
-| Inventory locations | 25 | |
+| Inventory locations | 19 | spec §3.4 zone codes (RCV/QA/STG-A..C/PCK/PKG/SHP); `TestNewInventoryLocation` errors on `n > 19` |
 | Inventory items | 30 | |
 | Transfer orders | 20 | |
 | Inventory transactions | 40 | |

--- a/docs/test/progress-seeding.md
+++ b/docs/test/progress-seeding.md
@@ -29,7 +29,7 @@ All values are randomized (names, IDs, dates). Only counts and relationships are
 | Cost history | 40 | historical, 180-day window |
 | Warehouses | 5 | historical, 365-day window |
 | Zones | 12 | |
-| Inventory locations | 25 | |
+| Inventory locations | 19 | spec §3.4 zone codes (RCV/QA/STG-A..C/PCK/PKG/SHP) |
 | Inventory items | 30 | |
 | Transfer orders | 20 | |
 | Inventory transactions | 40 | |


### PR DESCRIPTION
## Summary

Re-seeds `inventory.inventory_locations` from a 25-row algorithmic generation (`STG-A0102006`-style codes per spec §3.7) to a 19-row hardcoded catalogue matching spec §3.4 zone-layout codes — `RCV-01`, `RCV-02`, `QA-01`, `STG-A01..A03`, `STG-B01..B03`, `STG-C01..C03`, `PCK-01..03`, `PKG-01..02`, `SHP-01..02`. After this lands, scanning a physical `STG-A01` sticker on the floor app resolves via `LocationCodeExact` against `inventory_locations.location_code`, unblocking Phase 1 physical dogfood.

**Two logical units:**

**Re-seed (`testutil.go` + `seed_inventory.go`):**
- `business/domain/inventory/inventorylocationbus/testutil.go` — replaces algorithmic `{Zone}-{Aisle}{Rack}{Shelf}{Bin}` derivation with a hardcoded `specCodes` catalogue. Function honors caller `n` as a request count up to 19; returns explicit error if `n > 19` so future stale callers fail loudly. Output deterministic (no `math/rand`); non-aisled codes use `Aisle = ""` (schema-valid per `migrate.sql` v1.52 — `VARCHAR(20) NOT NULL`, no CHECK); STG codes carry real `Aisle = "A"/"B"/"C"`.
- `business/sdk/dbtest/seed_inventory.go` — dev seed call updated `n=25 → n=19`.

**Caller drift fix (17 files n=25 → n=19, plus 5 indexed-access updates):**

The bus-test fixture `TestSeedInventoryLocations` is called from 40+ files with various `n` values; 17 callers passed `n=25` and require the update. Five additional fixes address indexed-access patterns surfaced by the smaller catalogue:
- `inventoryitembus_test.go` Test_QueryAvailableForAllocation — bumped `TestSeedZone(ctx, 1, ...)` → `n=3` so all 3 requested locations resolve, plus added a post-seed `len(locations) == 3` guard (in-session review #1).
- `inventoryitembus_test.go` create/update subtests — index retargets `[5]/[6]` → `[15]/[18]` (post-shrink (location, product) collisions).
- `inventoryitembus_test.go` query subtest — `expItems` capped at 5 (was unbounded).
- `inventoryitemapi/create_test.go` — `[0]` → `[18]` (50-item seed grid collision on `Products[1]`).
- `inventorylocationapi/query_test.go` — `Total: 25 → 19` mechanical assertion update.

## Why this shape (DECISION 1 Path A)

Pre-flight Audit 3 (`docs/superpowers/plans/floor-physical-warehouse-testing/notes/phase-1/pre-flight.md` — gitignored) surfaced that `label_catalog` had 19 location codes from spec §3.4 but `inventory_locations` was algorithmically generated to spec §3.7. Workers scanning printed `STG-A01` stickers got zero matches. User locked Path A — re-seed `inventory_locations` to 19 spec codes — over Path C (introduce `label_catalog → inventory_location` join via `entity_ref`). Path C is semantically cleaner long-term and is filed as deferred backlog item D-036 for Phase 2.

**Drift bundling rationale (per `feedback_always_fix_drift` + `feedback_pr_mirrors_plan`):** the 5 indexed-access fixes weren't in the original plan's caller list, but they surfaced naturally once the catalogue shrunk. Bundling them into the re-seed PR (rather than deferring) keeps the tree green and the PR scope mirrors the actual change blast radius.

## Review cycles completed in-session

- **Spec compliance review** (Sonnet) — verified diff matches Steps 2.1-2.6 of the Phase 1 Track A plan; flagged no missing or extra spec items.
- **Code quality review** (Opus) — Approved-with-Important-notes: 2 Important findings (no Critical):
  - Pick/reserve alternation used catalogue index (`i%2`) rather than emission position (`len(out)%2`); fixed inline so partial-zone subsets still get balanced distribution.
  - FEFO/FIFO/LIFO subtest needed an explicit `len(locations) == 3` guard to make silent undershoot impossible if zone-cycle ↔ specCodes alignment ever drifts; fixed inline.
- **Re-test after fixes:** `go test ./business/domain/inventory/...` clean.

**Required before merge:** fresh-session `/code-review:code-review` against this PR (project convention — both in-session and fresh-session reviews mandatory).

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./business/domain/inventory/inventorylocationbus/...` — `ok`
- [x] `go test ./business/domain/inventory/...` (full bus-test set, 11 packages) — all `ok`
- [x] `go test ./business/sdk/dbtest/...` — `ok`
- [x] `go test ./business/sdk/tablebuilder/...` — `ok`
- [x] `go test ./business/sdk/workflow/workflowactions/inventory/...` — `ok`
- [x] `go test ./business/domain/paperwork/...` — `ok`
- [x] `go test ./api/cmd/services/ichor/tests/inventory/...` (17 sub-packages) — all `ok`
- [x] `go test ./api/cmd/services/ichor/tests/data/...` — `ok`
- [x] `go test ./api/cmd/services/ichor/tests/paperwork/...` — `ok`
- [x] `go test ./api/cmd/services/ichor/tests/floor/...` — `ok`
- [x] `go test ./api/cmd/services/ichor/tests/procurement/...` — `ok`
- [x] `go test ./api/cmd/services/ichor/tests/workflow/actionhandlers/...` — `ok`
- [ ] CI green
- [ ] Fresh-session `/code-review:code-review` clean
- [ ] After merge: `cd ../../../ichor && git pull --ff-only github master` BEFORE any `make dev-bounce` (project memory rule — required for seed-time consistency against the new `seed.sql`)
- [ ] After merge + `make dev-bounce`: smoke STG-A01 sticker scan in `/floor/receive` resolves to a real `inventory_location.id` (Step 2.6, post-merge gate)

## Companion frontend update

`e2e/fixtures/seed-ref.ts:205` `SEED_COUNTS.inventoryLocations: 25 → 19` lands in a separate frontend PR against `timmaaaz/ichor-frontend` `main`. The frontend constant is forward-compatible (any seeded count ≥19 satisfies `≥ SEED_COUNTS.inventoryLocations` assertions) — but to keep CI green post-merge, frontend should ship before this PR merges.

## Deferred follow-ups

Surfaced during review, explicitly out of scope:

- **D-036 — Path C `label_catalog → inventory_location` join via `entity_ref`** — semantically cleaner long-term (lookup goes through the canonical label registry rather than re-using the location-code column as scan key), but larger plumbing change. Filed in `docs/superpowers/plans/floor-physical-warehouse-testing/BACKLOG.md` (gitignored) for Phase 2.
- **Pre-existing `Test_FormData` failure** in `api/cmd/services/ichor/tests/formdata/formdataapi/` — `array for sales.order_line_items cannot be empty` from `formdataapp.UpsertFormData`. Verified pre-existing on `github/master` HEAD via `git stash` round-trip (NOT introduced by this branch). Tracked separately; not a gate for this PR.
- **`TestNewInventoryLocation` direct unit test coverage of new error branches** (`n > 19`, `n < 0`, empty `warehouseIDs`) — paths are simple guard returns; happy path exercised by all 40+ callers. Minor; would be nice but not required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)