### PR TITLE
fix(seed): address PR #146 review follow-ups

### DIFF
--- a/business/domain/inventory/inventoryitembus/inventoryitembus_test.go
+++ b/business/domain/inventory/inventoryitembus/inventoryitembus_test.go
@@ -188,10 +188,10 @@ func insertSeedData(busDomain dbtest.BusDomain) (unitest.SeedData, error) {
 
 func query(busDomain dbtest.BusDomain, sd unitest.SeedData) []unitest.Table {
 	// Filter to items belonging to Products[1]. Post-Phase-1 the grid is
-	// 30 items × 19 locations × 20 products: items 19-29 (11 items) carry
-	// Products[1]. The query below pages 5, so we cap expItems to the first
-	// 5 (DefaultOrderBy = id ASC; seed is pre-sorted by id, so positional
-	// order of expItems and got match).
+	// 30 items × 19 locations × 20 products: creation indices 19-29 (11 items)
+	// carry Products[1]. The query below pages 5, so we cap expItems to the first
+	// 5 (DefaultOrderBy = id ASC; seed is sorted by ID.String(), matching DB
+	// order within a run, so positional order of expItems and got match).
 	// Using a ProductID filter scopes the query to test-specific rows and
 	// avoids contamination from the global seed's inventory items.
 	p1ID := sd.Products[1].ProductID

--- a/business/domain/inventory/inventorylocationbus/testutil.go
+++ b/business/domain/inventory/inventorylocationbus/testutil.go
@@ -22,8 +22,9 @@ type specCode struct {
 }
 
 // specCodes is the canonical, alphabetically-sorted catalogue of the 19
-// physical location codes. Order is fixed so callers indexing the returned
-// slice (e.g. sd.InventoryLocations[0]) get deterministic results across runs.
+// physical location codes. The var order drives insertion; the seeded slice
+// is re-sorted by LocationID.String() so positional indices match the bus
+// query's ORDER BY id ASC within a run (UUIDs are fresh per run).
 var specCodes = []specCode{
 	{code: "PCK-01", zonePfx: "PCK", aisle: "", rack: "01"},
 	{code: "PCK-02", zonePfx: "PCK", aisle: "", rack: "02"},

--- a/business/sdk/dbtest/seed_inventory.go
+++ b/business/sdk/dbtest/seed_inventory.go
@@ -79,7 +79,12 @@ func seedInventory(ctx context.Context, busDomain BusDomain, foundation Foundati
 		return InventorySeed{}, fmt.Errorf("seeding inventory products : %w", err)
 	}
 
-	_, err = transferorderbus.TestSeedTransferOrders(ctx, 20, productIDs, inventoryLocationsIDs[:15], inventoryLocationsIDs[15:], reporterIDs[:4], bossIDs[4:], nil, busDomain.TransferOrder)
+	// Split inventoryLocationsIDs into two non-overlapping pools for transfer-order
+	// from/to. TestSeedTransferOrders cycles each pool with %len, so balance and
+	// non-emptiness matter more than which side is larger; mid scales with the
+	// seeded count so future resizes don't silently shrink the dest pool or panic.
+	mid := len(inventoryLocationsIDs) / 2
+	_, err = transferorderbus.TestSeedTransferOrders(ctx, 20, productIDs, inventoryLocationsIDs[:mid], inventoryLocationsIDs[mid:], reporterIDs[:4], bossIDs[4:], nil, busDomain.TransferOrder)
 	if err != nil {
 		return InventorySeed{}, fmt.Errorf("seeding transfer orders : %w", err)
 	}

--- a/business/sdk/dbtest/seed_scenarios_refs_test.go
+++ b/business/sdk/dbtest/seed_scenarios_refs_test.go
@@ -28,7 +28,7 @@ func fixedLookups(t *testing.T) refLookups {
 			return productID, nil
 		},
 		locationIDByCode: func(_ context.Context, code string) (uuid.UUID, error) {
-			if code != "RCV-A010101" {
+			if code != "RCV-01" {
 				return uuid.Nil, errors.New("not found")
 			}
 			return locationID, nil
@@ -101,7 +101,7 @@ func TestResolveRefs(t *testing.T) {
 			name: "three refs together",
 			in: map[string]any{
 				"product_ref":  "SKU-0001",
-				"location_ref": "RCV-A010101",
+				"location_ref": "RCV-01",
 				"tote_ref":     "TOTE-001",
 			},
 			expect: map[string]any{

--- a/deployments/scenarios/rush-receiving/bindings.yaml
+++ b/deployments/scenarios/rush-receiving/bindings.yaml
@@ -6,7 +6,7 @@
 #
 # - totes:     inventory.label_catalog.code (Phase 0b format "TOTE-%03d")
 # - locations: inventory.inventory_locations.location_code
-#              (Phase 0c format "{ZoneCode}-{Aisle}{Rack}{Shelf}{Bin}")
+#              (spec §3.4 catalogue: "{ZoneCode}-{NN}" or "{ZoneCode}-{Aisle}{NN}")
 # - lots:      scenario-scoped blueprints; ref is an FK handle used within
 #              this scenario's state.yaml. product_code matches the 0c
 #              product SKU format ("SKU-%04d").
@@ -17,11 +17,11 @@ totes:
   - code: TOTE-003
 
 locations:
-  - code: RCV-A010101
+  - code: RCV-01
     role: inbound
-  - code: RCV-A010102
+  - code: RCV-02
     role: inbound
-  - code: STG-A010203
+  - code: STG-A01
     role: storage
 
 lots:


### PR DESCRIPTION
## Summary

Post-merge follow-ups from a `/code-review` pass on PR #146. Five small fixes — three correctness, two doc clarity — touching only test/seed/scenario glue. No production behavior change.

- **rush-receiving bindings + resolver stub**: PR #146 dropped the old algorithmic location codes (`RCV-A010101`, `RCV-A010102`, `STG-A010203`) but `deployments/scenarios/rush-receiving/bindings.yaml` and the matching stub in `seed_scenarios_refs_test.go` still referenced them. Once anything wires `state.yaml` through `SeedScenariosFromRoot`, the resolver in `seed_scenarios_refs.go` (line 65–76) would error with `location not found for code=...`. Replaced with valid §3.4 codes (`RCV-01`, `RCV-02`, `STG-A01`) preserving the original `inbound`/`storage` roles, and refreshed the format-doc comment.
- **transfer-order pool split**: `seed_inventory.go:82` used a hardcoded `inventoryLocationsIDs[:15]/[15:]` split. With n=25 that was 15 src / 10 dst; PR #146 reduced n to 19 making it 15/4, and any future drop below 16 would panic on `[15:]`. Replaced with `mid := len(...)/2` so the split scales with the seed count (current: 9/10 — both pools non-empty, balanced).
- **`specCodes` doc comment**: previous wording overclaimed "deterministic results across runs." The seeded slice is sorted by `LocationID.String()` (UUIDs are fresh per run), so positional indices match `ORDER BY id ASC` *within* a run, not across. Tightened wording.
- **`inventoryitembus_test.go` query() comment**: clarified that "items 19-29" are *creation indices* (not `sd.InventoryItems[19..29]`) and that the seed is sorted by `ID.String()`. The functional code already filters by `ProductID`, so behavior is unchanged.

## Test plan

- [x] `go vet` clean on `business/sdk/dbtest/...`, `business/domain/inventory/inventorylocationbus/...`, `business/domain/inventory/inventoryitembus/...`
- [x] `TestResolveRefs` passes (validates the stub guard + "three refs together" case)
- [x] Inventory test packages compile (`go test -run __NONE__`)
- [ ] Reviewer: verify the spec §3.4 code choices match scenario intent (`RCV-01`/`RCV-02` for inbound, `STG-A01` for storage)

🤖 Generated with [Claude Code](https://claude.ai/code)